### PR TITLE
chore(random_password): update random password hook

### DIFF
--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/hooks/user/user.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/hooks/user/user.php
@@ -242,7 +242,7 @@ function validateComplexPassword($errors)
  * must be truncated
  */
 add_filter('random_password', function ($pass) {
-    $pass = substr($pass, 0, Conf::PASSWORD_LENGTH);
+    $pass = substr($pass, 0, Conf::PASSWORD_LENGTH-1);
     return $pass;
 }, 10, 1);
 

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/hooks/user/user.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/hooks/user/user.php
@@ -242,8 +242,7 @@ function validateComplexPassword($errors)
  * must be truncated
  */
 add_filter('random_password', function ($pass) {
-    $pass = substr($pass, 0, Conf::PASSWORD_LENGTH-1);
-    return $pass;
+    return substr($pass, 0, Conf::PASSWORD_LENGTH-1);
 }, 10, 1);
 
 


### PR DESCRIPTION
The CMS actually check if the password is `>= Conf::PASSWORD_LENGTH`, so, the password generated randomly by random_password hook shoul be LESS than `Conf::PASSWORD_LENGTH`.