### PR TITLE
Add new capabilities for some acore views

### DIFF
--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/components/AdminPanel/AdminPanel.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/components/AdminPanel/AdminPanel.php
@@ -110,4 +110,9 @@ function admin_panel_init()
         add_action( 'admin_menu', array( $adminPanel, 'acore_add_pages' ), 8);
     }
 
+    // get administrator role and add new acore capabilities
+    $role = get_role( 'administrator' );
+    $role->add_cap( 'game_master' );
+    $role->add_cap( 'manage_pvp_rewards' );
+
 }

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/components/AdminPanel/Settings.controller.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/components/AdminPanel/Settings.controller.php
@@ -27,7 +27,7 @@ class SettingsController {
 
     public function loadHome() {
         //must check that the user has the required capability
-        if (!current_user_can('manage_options')) {
+        if (!current_user_can('game_master')) {
             wp_die(__('You do not have sufficient permissions to access this page.'));
         }
 
@@ -39,7 +39,7 @@ class SettingsController {
 
     public function loadSettings() {
         //must check that the user has the required capability
-        if (!current_user_can('manage_options')) {
+        if (!is_admin()) {
             wp_die(__('You do not have sufficient permissions to access this page.'));
         }
 
@@ -65,7 +65,7 @@ class SettingsController {
 
     public function loadElunaSettings() {
         //must check that the user has the required capability
-        if (!current_user_can('manage_options')) {
+        if (!is_admin()) {
             wp_die(__('You do not have sufficient permissions to access this page.'));
         }
 
@@ -91,7 +91,7 @@ class SettingsController {
 
     public function loadPvpRewards() {
         //must check that the user has the required capability
-        if (!current_user_can('manage_options')) {
+        if (!current_user_can('manage_pvp_rewards')) {
             wp_die(__('<div class="notice notice-error"><p>You do not have sufficient permissions to access this page.</p></div>'));
         }
 


### PR DESCRIPTION
Add 2 new capabilities for easier management for some actual views (and probably new ones in the future):
- game_master
- manage_pvp_rewards

Both are added by default to administrator role and can be added to other roles with a plugin (like [User Role Editor](https://wordpress.org/plugins/user-role-editor/)) or by modifying it directly in the database in the options table (not recommended).