### PR TITLE
fix: use char guid if character order is null

### DIFF
--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/CharactersMenu/CharactersController.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/CharactersMenu/CharactersController.php
@@ -25,7 +25,7 @@ class CharactersController {
             `guid`, `name`, `order`, `race`, `class`, `level`, `gender`
             FROM `characters`
             WHERE `characters`.`deleteDate` IS NULL AND `account` = $accId
-            ORDER BY `order`, `guid`
+            ORDER BY COALESCE(`order`, `guid`)
         ";
         $conn = ACoreServices::I()->getCharacterEm()->getConnection();
         $queryResult = $conn->executeQuery($query);


### PR DESCRIPTION
Use the character's guid if the order value is null to sort the character order list (see https://github.com/azerothcore/acore-cms/pull/52).
This makes newly created characters go to the bottom of the characters list instead of the top.