### PR TITLE
Feature soap logs view

### DIFF
--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/acore-wp-plugin.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/acore-wp-plugin.php
@@ -21,3 +21,5 @@ $loader = require ACORE_PATH_PLG . 'vendor/autoload.php';
 AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 
 require ACORE_PATH_PLG . "/src/boot.php";
+
+register_activation_hook( __FILE__, 'activate_acore_wp_plugin' );

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/AdminPanel/AdminPanel.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/AdminPanel/AdminPanel.php
@@ -59,6 +59,13 @@ class AdminPanel
         $SettingsCtrl->loadTools();
     }
 
+    // mt_settings_page() displays the page content for the Test settings submenu
+    function acore_soap_logs_page()
+    {
+        $SettingsCtrl = new SettingsController();
+        $SettingsCtrl->loadSoapLogs();
+    }
+
     // action function for above hook
     function acore_add_pages()
     {
@@ -100,6 +107,16 @@ class AdminPanel
             'manage_options',
             ACORE_SLUG . '-tools',
             array($this, 'acore_tools_page')
+        );
+
+        // Add a new submenu under Settings:
+        add_submenu_page(
+            'acore',
+            __('ACore Settings Panel', Opts::I()->org_alias),
+            __('Soap Logs', Opts::I()->org_alias),
+            'manage_options',
+            ACORE_SLUG . '-soap-logs',
+            array($this, 'acore_soap_logs_page')
         );
     }
 

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/AdminPanel/Pages/SoapLogs.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/AdminPanel/Pages/SoapLogs.php
@@ -1,0 +1,146 @@
+<?php
+    use ACore\Manager\Opts;
+    // Now display the settings editing screen
+    $myCredConfs = get_option('mycred_pref_core');
+?>
+
+<div class="wrap">
+    <h2> <?= __('Soap Logs', Opts::I()->page_alias)?> </h2>
+    <p>A list of the logged commands.</p>
+    <div class="row">
+        <div class="col">
+            <div class="card p-0">
+                <div class="card-body">
+                    <h5>Soap Logs</h5>
+                    <hr>
+                    <form class="row row-cols-lg-auto g-2" url="<?php echo menu_page_url(ACORE_SLUG . '-soap-logs'); ?>">
+                        <input type="hidden" value="<?php echo ACORE_SLUG . '-soap-logs'; ?>" name="page">
+                        <div class="col">
+                            <label class="visually-hidden" for="username">Username</label>
+                            <input type="text" class="form-control form-control-sm" id="username" name="username" placeholder="Username" value="<?php echo $data['username']; ?>">
+                        </div>
+                        <div class="col">
+                            <label class="visually-hidden" for="order_id">Order ID</label>
+                            <input type="text" class="form-control form-control-sm" id="order_id" name="order_id" placeholder="Order ID" value="<?php echo $data['order_id']; ?>">
+                        </div>
+
+                        <div class="col">
+                            <label class="visually-hidden" for="items">Items</label>
+                            <select class="form-select" name="items" id="items">
+                                <option value="10">10</option>
+                                <option value="25" <?php echo $data['items'] == '25' ? 'selected' : ''; ?>>25</option>
+                                <option value="50" <?php echo $data['items'] == '50' ? 'selected' : ''; ?>>50</option>
+                                <option value="100" <?php echo $data['items'] == '100' ? 'selected' : ''; ?>>100</option>
+                            </select>
+                        </div>
+
+                        <div class="col">
+                            <button type="submit" class="btn btn-primary btn-sm">Search</button>
+                        </div>
+
+                        <div class="col ms-auto">
+                            <nav aria-label="Table pagination">
+                                <ul class="pagination pagination-sm">
+                                    <?php
+                                        $maxPagination = 3;
+                                        $diff = $data["max_page"] - $data["pos"];
+                                        $start = $data["pos"] - $maxPagination > 0 && $diff >= 0 ? $data["pos"] - $maxPagination : 1;
+                                        $end = $data["pos"] + $maxPagination < $data["max_page"] && $diff > 0 ? $data["pos"] + $maxPagination : $data["max_page"];
+
+                                        $link = menu_page_url(ACORE_SLUG . '-soap-logs', false);
+                                        if ($data["username"]) {
+                                            $link .= "&username" . $data["username"];
+                                        }
+                                        if ($data["order_id"]) {
+                                            $link .= "&order_id" . $data["order_id"];
+                                        }
+                                        ?>
+
+                                        <li class="page-item disabled">
+                                        <?php if ($data["count"] > 0): ?>
+                                        <a class="page-link">Results <?php echo ($data["pos"] - 1) * $data["items"] + 1; ?> to <?php echo $data["pos"] != $data["max_page"] ? $data["pos"] * $data["items"] : $data["count"]; ?> from <?php echo $data["count"]; ?> </a>
+                                        <?php else: ?>
+                                            <a class="page-link">No results </a>
+                                        <?php endif; ?>
+                                        </li>
+
+                                        <?php
+                                        $link .= "&items=" . $data["items"];
+                                        if ($start > 1) {
+                                            echo "<li class=\"page-item\"><a class=\"page-link\" href=\"$link&pos=1\">1</a></li>";
+                                            if ($maxPagination <= $start) {
+                                                echo "<li class=\"page-item disabled\"><a class=\"page-link\">...</a></li>";
+                                            }
+                                        }
+                                        for ($i = $start; $i <= $end; $i++) {
+                                            $href = "$link&pos=$i";
+                                            $class = "";
+                                            if ($i == $data["pos"]) {
+                                                $href = "#";
+                                                $class = " active";
+                                            }
+                                            echo "<li class=\"page-item{$class}\"><a class=\"page-link\" href=\"{$href}\">$i</a></li>";
+                                        }
+                                        if ($end < $data["max_page"]) {
+                                            if ($data["max_page"] - 1 != $end) {
+                                                echo "<li class=\"page-item disabled\"><a class=\"page-link\">...</a></li>";
+                                            }
+                                            echo "<li class=\"page-item\"><a class=\"page-link\" href=\"$link&pos={$data["max_page"]}\">{$data["max_page"]}</a></li>";
+                                        }
+                                    ?>
+                                </ul>
+                            </nav>
+                        </div>
+
+                    </form>
+                    <table class="table table-bordered table-hover align-middle">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>Result</th>
+                                <th>Details</th>
+                                <th>Command</th>
+                                <th>User</th>
+                                <th>Order</th>
+                                <th>Executed DateTime</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php
+                            foreach ($result as $item) {
+                                echo "<tr><td>{$item->id}</td>";
+                                if ($item->success) {
+                                    echo "<td><span class=\"dashicons dashicons-yes text-success\"></span></td>";
+                                } else {
+                                    echo "<td><span class=\"dashicons dashicons-no text-danger\"></span></td>";
+                                }
+                                echo "<td>{$item->result}</td>";
+                                echo "<td>{$item->command}</td>";
+                                $user_info = get_userdata($item->user_id);
+                                echo "<td><a href=\"" . get_edit_user_link($item->user_id) . "\">{$user_info->user_login}</a></td>";
+                                echo "<td>{$item->order_id}</td>";
+                                echo "<td>{$item->executed_at}</td></tr>";
+                            }
+                            ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+    <hr />
+    <script>
+        jQuery('#preview').on('click', function (e) {
+            jQuery('#pvp-rewards').attr('method', 'GET');
+        });
+        jQuery('#pvp-rewards').on('submit', function (e) {
+            return confirm("You sure you want to continue?");
+        });
+        jQuery(document).on('ready', function () {
+            var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+            tooltipTriggerList.forEach(function (tooltipTriggerEl) {
+                return new bootstrap.Tooltip(tooltipTriggerEl)
+            });
+        });
+    </script>
+</div>

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/AdminPanel/SettingsController.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/AdminPanel/SettingsController.php
@@ -356,7 +356,7 @@ class SettingsController {
                         $result = ACoreServices::I()->getServerSoap()->executeCommand("item restore list");
                          if (strpos($result, '.item restore list'))
                             $this->storeConf($key, $_POST[$key]);
-                        else 
+                        else
                          print "<div class='error'><p><strong>Item restore service error: $result</strong></p></div>";
                     }
                     else {
@@ -366,12 +366,86 @@ class SettingsController {
             }
 
             // Reload configs
-            $this->data = $this->loadData(); 
+            $this->data = $this->loadData();
             ?>
                 <div class="updated"><p><strong>Tools have been saved</strong></p></div>
             <?php
         }
         echo $this->getView()->getToolsRender();
+    }
+
+    public function loadSoapLogs() {
+        # defaults
+        $items = 10;
+        $pos = 1;
+        $userName = null;
+        $orderId = null;
+        $from = null;
+        $to = null;
+
+        if (!is_admin()) {
+            wp_die(__('You do not have sufficient permissions to access this page.'));
+        }
+        global $wpdb;
+        $soapLogsTableName = $wpdb->prefix . ACORE_SOAP_LOGS_TABLENAME;
+        $query = "SELECT
+            sl.*
+        FROM $soapLogsTableName sl
+        ##JOIN USERS##
+        WHERE
+            1=1
+            ##WHERE USERS##
+        ";
+        if (isset($_GET["username"]) && !empty($_GET["username"])) {
+            $userName = $_GET['username'];
+            $query = str_replace("##JOIN USERS##", "INNER JOIN {$wpdb->users} u ON sl.user_id = u.ID", $query);
+            $query = str_replace("##WHERE USERS##", " AND u.user_login LIKE '%{$wpdb->_real_escape($userName)}%'", $query);
+        } else {
+            $query = str_replace("##JOIN USERS##", "", $query);
+            $query = str_replace("##WHERE USERS##", "", $query);
+        }
+        if (isset($_GET["order_id"]) && filter_var($_GET["order_id"], FILTER_VALIDATE_INT)) {
+            $orderId = (int) $_GET['order_id'];
+            $query .= " AND sl.order_id = $orderId";
+        }
+        if (isset($_GET["from"]) && isset($_GET["to"])) {
+            $from = $wpdb->_real_escape($_GET['from']);
+            $to = $wpdb->_real_escape($_GET['to']);
+            $query .= " AND sl.executed_at BETWEEN '{$from}::00:00:00' AND '{$to}::23:59:59'";
+        }
+        if (isset($_GET["items"]) && in_array($_GET["items"], ["10", "25", "50", "100"])) {
+            $items = (int) $_GET['items'];
+        }
+        if (isset($_GET["pos"])) {
+            $pos = (int) $_GET['pos'];
+            if ($pos <= 0) {
+                $pos = 1;
+            }
+        }
+
+        $count = $wpdb->get_col("SELECT count(0) FROM ($query) total");
+
+        $offset = ($pos - 1) * $items;
+        $query .= " LIMIT $items OFFSET $offset";
+
+        $result = $wpdb->get_results($query);
+        $maxPage = ceil((int) $count[0] / $items);
+
+        $data = [
+            'username' => $userName,
+            'order_id' => $orderId,
+            'from' => $from,
+            'to' => $to,
+            'items' => $items,
+            'pos' => $pos,
+            'count' => (int) $count[0],
+            'max_page' => $maxPage,
+        ];
+
+        echo $this->getView()->getSoapLogsRender(
+            $data,
+            $result
+        );
     }
 
 

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/AdminPanel/SettingsView.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/AdminPanel/SettingsView.php
@@ -36,6 +36,10 @@ class SettingsView {
         return $this->loadPageLayout('Tools');
     }
 
+    public function getSoapLogsRender($data, $result) {
+        return $this->loadPageLayout('SoapLogs', ['data' => $data, 'result' => $result]);
+    }
+
     private function loadPageLayout($pageName, $varExtract=null) {
         wp_enqueue_style('bootstrap-css', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css', array(), '5.1.3');
         wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.1');

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/Tools/ToolsApi.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/Tools/ToolsApi.php
@@ -13,7 +13,7 @@ class ToolsApi {
     public static function ItemRestore($data) {
         $item = $data['item'];
         $cname = $data['cname'];
-        return ACoreServices::I()->getServerSoap()->executeCommand("item restore $item $cname");
+        return ACoreServices::I()->getServerSoap()->executeCommand("item restore $item $cname", true);
     }
 }
 

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/UserPanel/UserController.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/UserPanel/UserController.php
@@ -78,7 +78,7 @@ class UserController {
                         if ($res instanceof \Exception) {
                             $errorMessages[] = "The server seems to be offline, try again later!";
                         } else {
-                            $res = $soap->executeCommand("bindraf $newRecruitId $recruiterCode");
+                            $res = $soap->executeCommand("bindraf $newRecruitId $recruiterCode", true);
                             if ($res instanceof \Exception) {
                                 $errorMessages[] = "An error ocurred while binding accounts. Please try again later.";
                             }
@@ -129,7 +129,6 @@ class UserController {
 
     public function showItemRestorationPage() {
         if ($_SERVER["REQUEST_METHOD"] == "POST") {
-            $this->saveCharacterOrder();
             ?>
             <div class="updated"><p><strong>Character settings succesfully saved.</strong></p></div>
             <?php

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Hooks/WooCommerce/CharChange.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Hooks/WooCommerce/CharChange.php
@@ -137,7 +137,7 @@ class CharChange extends \ACore\Lib\WpClass {
                             if (!$charName) {
                                 throw new \Exception("No character found, please check your selection.");
                             }
-                            $res = $soap->changeName($charName);
+                            $res = $soap->changeName($charName, null, $order_id);
                             if ($res instanceof \Exception) {
                                 throw new \Exception("There was an error with character rename on $charName - " . $res->getMessage());
                             }
@@ -147,7 +147,7 @@ class CharChange extends \ACore\Lib\WpClass {
                             if (!$charName) {
                                 throw new \Exception("No character found, please check your selection.");
                             }
-                            $res = $soap->changeFaction($charName);
+                            $res = $soap->changeFaction($charName, $order_id);
                             if ($res instanceof \Exception) {
                                 throw new \Exception("There was an error with character change faction on $charName - " . $res->getMessage());
                             }
@@ -157,7 +157,7 @@ class CharChange extends \ACore\Lib\WpClass {
                             if (!$charName) {
                                 throw new \Exception("No character found, please check your selection.");
                             }
-                            $res = $soap->changeRace($charName);
+                            $res = $soap->changeRace($charName, $order_id);
                             if ($res instanceof \Exception) {
                                 throw new \Exception("There was an error with character change race on $charName - " . $res->getMessage());
                             }
@@ -167,7 +167,7 @@ class CharChange extends \ACore\Lib\WpClass {
                             if (!$charName) {
                                 throw new \Exception("No character found, please check your selection.");
                             }
-                            $res = $soap->charCustomization($charName);
+                            $res = $soap->charCustomization($charName, $order_id);
                             if ($res instanceof \Exception) {
                                 throw new \Exception("There was an error with character customization on $charName - " . $res->getMessage());
                             }
@@ -175,7 +175,7 @@ class CharChange extends \ACore\Lib\WpClass {
                         case "char-restore-delete":
                             $charName = $WoWSrv->getCharName($item["acore_char_sel"], true);
                             $guid = $item["acore_char_sel"];
-                            self::charRestore($guid, $charName);
+                            self::charRestore($guid, $charName, $order_id);
                             break;
                     }
                 }
@@ -185,7 +185,7 @@ class CharChange extends \ACore\Lib\WpClass {
         }
     }
 
-    private static function charRestore($guid, $charName) {
+    private static function charRestore($guid, $charName, $order_id) {
         $soap = ACoreServices::I()->getCharactersSoap();
         $query = "SELECT `guid`, `name` FROM `characters` WHERE `characters`.`name` = ?";
         $conn = ACoreServices::I()->getCharacterEm()->getConnection();
@@ -198,13 +198,13 @@ class CharChange extends \ACore\Lib\WpClass {
             $res = $soap->charRestore($guid, $charName . "èè");
             $newName = true;
         } else {
-            $res = $soap->charRestore($guid);
+            $res = $soap->charRestore($guid, $order_id);
         }
 
         if ($res instanceof \Exception) {
             throw new \Exception("There was an error with character restore delete on $charName - " . $res->getMessage());
         } else if ($newName) {
-            $res = $soap->changeName($charName . "èè");
+            $res = $soap->changeName($charName . "èè", null, $order_id);
             if ($res instanceof \Exception) {
                 throw new \Exception("There was an error renaming your character " . $res->getMessage());
             }

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/AccountService.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/AccountService.php
@@ -47,9 +47,9 @@ class AccountService {
 
     /**
      * This is a static mail that won't change
-     * @param type $username
-     * @param type $email
-     * @return type
+     * @param string $username
+     * @param string $email
+     * @return mixed
      */
     public function setAccountRegMail($username, $email) {
         $email = strtolower($email);
@@ -83,7 +83,7 @@ class AccountService {
 
     // CarbonCopy tickets - https://github.com/55Honey/Acore_CarbonCopy/
     public function addCCTickets($accoutName, $quantity) {
-        return $this->executeCommand("CCACCOUNTTICKETS $accoutName $quantity");
+        return $this->executeCommand("CCACCOUNTTICKETS $accoutName $quantity", true);
     }
 
 }

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/AcoreSoap.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/AcoreSoap.php
@@ -39,8 +39,8 @@ class AcoreSoap
             $user = wp_get_current_user();
             $userId = $user->ID;
             $soapLogsTableName = $wpdb->prefix . ACORE_SOAP_LOGS_TABLENAME;
-            $query = "INSERT INTO `$soapLogsTableName` (`user_id`, `command`, `success`, `result`, `order_id`)
-            VALUES ?, ?, ?, ?, ?";
+            $query = "INSERT INTO `$soapLogsTableName` (`user_id`, `command`, `success`, `result`, `order_id`, `executed_at`)
+            VALUES ?, ?, ?, ?, ?, NOW()";
         }
 
         try {

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/AcoreSoap.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/AcoreSoap.php
@@ -18,7 +18,7 @@ class AcoreSoap
         return $this->params != null;
     }
 
-    public function executeCommand($command)
+    public function executeCommand($command, $logCommand = false, $orderId = null)
     {
         if (!$this->params) {
             throw new \Exception("Soap service is not configured, please use configure() function before!");
@@ -33,11 +33,26 @@ class AcoreSoap
             'trace' => 1,
             'keep_alive' => false //php 5.4 only
         ));
+        global $wpdb;
+        $userId = null;
+        if ($logCommand) {
+            $user = wp_get_current_user();
+            $userId = $user->ID;
+            $soapLogsTableName = $wpdb->prefix . ACORE_SOAP_LOGS_TABLENAME;
+            $query = "INSERT INTO `$soapLogsTableName` (`user_id`, `command`, `success`, `result`, `order_id`)
+            VALUES ?, ?, ?, ?, ?";
+        }
 
         try {
             $result = $soap->executeCommand(new \SoapParam($command, 'command'));
+            if ($logCommand) {
+                $wpdb->query($query, [$userId, $command, 1, $result, $orderId]);
+            }
             return $result;
         } catch (\Exception $e) {
+            if ($logCommand) {
+                $wpdb->query($query, [$userId, $command, 0, $e->getMessage(), $orderId]);
+            }
             return $e->getMessage();
         }
     }

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/AcoreSoap.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/AcoreSoap.php
@@ -40,7 +40,7 @@ class AcoreSoap
             $userId = $user->ID;
             $soapLogsTableName = $wpdb->prefix . ACORE_SOAP_LOGS_TABLENAME;
             $query = "INSERT INTO `$soapLogsTableName` (`user_id`, `command`, `success`, `result`, `order_id`, `executed_at`)
-            VALUES ?, ?, ?, ?, ?, NOW()";
+            VALUES (?, ?, ?, ?, ?, NOW())";
         }
 
         try {

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/AcoreSoapTrait.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/AcoreSoapTrait.php
@@ -28,8 +28,8 @@ trait AcoreSoapTrait {
         $this->soap->configure($params);
     }
 
-    public function executeCommand($command) {
-        return $this->getSoap()->executeCommand($command);
+    public function executeCommand($command, $logCommand = false, $orderId = null) {
+        return $this->getSoap()->executeCommand($command, $logCommand, $orderId);
     }
 
 }

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/CharacterService.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/CharacterService.php
@@ -8,24 +8,44 @@ class CharacterService {
 
     use AcoreSoapTrait;
 
-    public function changeName($charName, $newName = NULL) {
-        return $this->executeCommand(".character rename $charName $newName");
+    public function changeName($charName, $newName = null, $orderId = null) {
+        return $this->executeCommand(
+            ".character rename $charName $newName",
+            true,
+            $orderId
+        );
     }
 
-    public function changeFaction($charName) {
-        return $this->executeCommand(".character changefaction $charName");
+    public function changeFaction($charName, $orderId = null) {
+        return $this->executeCommand(
+            ".character changefaction $charName",
+            true,
+            $orderId
+        );
     }
 
-    public function changeRace($charName) {
-        return $this->executeCommand(".character changerace $charName");
+    public function changeRace($charName, $orderId = null) {
+        return $this->executeCommand(
+            ".character changerace $charName",
+            true,
+            $orderId
+        );
     }
 
-    public function charCustomization($charName) {
-        return $this->executeCommand(".character customize $charName");
+    public function charCustomization($charName, $orderId = null) {
+        return $this->executeCommand(
+            ".character customize $charName",
+            true,
+            $orderId
+        );
     }
 
-    public function charRestore($charGuid, $newName = NULL) {
-        return $this->executeCommand(".character deleted restore $charGuid $newName");
+    public function charRestore($charGuid, $newName = null, $orderId = null) {
+        return $this->executeCommand(
+            ".character deleted restore $charGuid $newName",
+            true,
+            $orderId
+        );
     }
 
 }

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/MailService.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Soap/MailService.php
@@ -13,14 +13,14 @@ class MailService {
         $_subject = addslashes($subject);
         $_itemId = intval($itemId);
         $_stack = intval($stack);
-        return $this->executeCommand('.send items  ' . $playerName . ' "' . $_subject . '" "' . $_message . '" ' . $_itemId . ':' . $_stack);
+        return $this->executeCommand(".send items $playerName \"$_subject\" \"$_message\" $_itemId :$_stack");
     }
 
     public function sendMoney($playerName, $subject, $message, $money) {
         $_message = addslashes(self::removeEmoji($message));
         $_subject = addslashes($subject);
         $money = intval($money);
-        return $this->executeCommand('.send items  ' . $playerName . ' "' . $_subject . '" "' . $_message . '" ' . $money);
+        return $this->executeCommand(".send items $playerName \"$_subject\" \"$_message\" $money");
     }
 
     // requires https://github.com/55Honey/Acore_SendAndBind
@@ -28,7 +28,7 @@ class MailService {
         $_message = addslashes(self::removeEmoji($message));
         $_itemId = intval($itemId);
         $_stack = intval($stack);
-        return $this->executeCommand('.senditemandbind ' . $guid . ' ' . $_itemId . ' ' . $_stack . ' ' . $_message);
+        return $this->executeCommand(".senditemandbind $guid $_itemId $_stack $_message");
     }
 
     public static function removeEmoji($text): string

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Tables.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Tables.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ACore\Manager;
+
+define("ACORE_SOAP_LOGS_TABLENAME", "acore_soap_logs");
+
+/**
+ * @since 0.1
+ */
+function create_acore_soap_logs_table() {
+    global $wpdb;
+    global $acore_db_version;
+    $charset_collate = $wpdb->get_charset_collate();
+
+    //* Create acore_soap_logs table
+    $table_name = $wpdb->prefix . ACORE_SOAP_LOGS_TABLENAME;
+    $sql = "CREATE TABLE $table_name (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    success TINYINT(1) NOT NULL,
+    command TEXT NOT NULL,
+    result TEXT,
+    user_id BIGINT UNSIGNED,
+    order_id BIGINT UNSIGNED,
+    PRIMARY KEY (id)
+    ) $charset_collate;";
+
+    require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
+    dbDelta( $sql );
+}

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Tables.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Tables.php
@@ -9,7 +9,6 @@ define("ACORE_SOAP_LOGS_TABLENAME", "acore_soap_logs");
  */
 function create_acore_soap_logs_table() {
     global $wpdb;
-    global $acore_db_version;
     $charset_collate = $wpdb->get_charset_collate();
 
     //* Create acore_soap_logs table

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Tables.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Manager/Tables.php
@@ -15,12 +15,13 @@ function create_acore_soap_logs_table() {
     //* Create acore_soap_logs table
     $table_name = $wpdb->prefix . ACORE_SOAP_LOGS_TABLENAME;
     $sql = "CREATE TABLE $table_name (
-    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    success TINYINT(1) NOT NULL,
-    command TEXT NOT NULL,
-    result TEXT,
-    user_id BIGINT UNSIGNED,
-    order_id BIGINT UNSIGNED,
+    `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `success` TINYINT(1) NOT NULL,
+    `command` TEXT NOT NULL,
+    `result` TEXT,
+    `user_id` BIGINT UNSIGNED,
+    `order_id` BIGINT UNSIGNED,
+    `executed_at` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
     PRIMARY KEY (id)
     ) $charset_collate;";
 

--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/boot.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/boot.php
@@ -16,3 +16,12 @@ require_once ACORE_PATH_PLG . 'src/Hooks/Various/tgmplugin_activator.php';
 require_once ACORE_PATH_PLG . 'src/Hooks/User/Include.php';
 
 require_once ACORE_PATH_PLG . 'src/Hooks/WooCommerce/WooCommerce.php';
+
+require_once ACORE_PATH_PLG . 'src/Manager/Tables.php';
+
+
+function activate_acore_wp_plugin()
+{
+    ACore\Manager\create_acore_soap_logs_table();
+    do_action('activate_acore_wp_plugin');
+}


### PR DESCRIPTION
## Goal

List some SOAP commands executed from de CMS in favor to have more information in case of some purchase fails or something wrong happens.

**Features**

    * New view Soap Logs


## Proposed changes

    * Add a new option to the executeCommand function to allow log it and add an order_id if applies.


## Code

**AC-CMS ADMIN**

    * [x]  Base service file/handler

    * [x]  New table wp_acore_soap_logs

    * [x]  New view Soap Logs available just for WP admins

    * [x]  Filter by username and order id

    * [x]  Allow pagination
