### PR TITLE
fix: add error fallback when no character exist on the account

### DIFF
--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Hooks/WooCommerce/CartValidation.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Hooks/WooCommerce/CartValidation.php
@@ -62,6 +62,11 @@ class CartValidation extends \ACore\Lib\WpClass {
             return false;
         }
 
+        if(!isset($_REQUEST['acore_char_sel'])) {
+            \wc_add_notice(__('Character not found. Select character and try again.', 'woocommerce'), 'error');
+            return false;
+        }
+
         if (in_array('acore_char_sel', self::$skuList[$activeSku])) {
             $guid = intval($_REQUEST['acore_char_sel']);
 


### PR DESCRIPTION
Error message for when a user tries to add item to cart and no character is selected