### PR TITLE
fix(CartValidation): check character selection only if needed

### DIFF
--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Hooks/WooCommerce/CartValidation.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Hooks/WooCommerce/CartValidation.php
@@ -62,16 +62,11 @@ class CartValidation extends \ACore\Lib\WpClass {
             return false;
         }
 
-        if(!isset($_REQUEST['acore_char_sel'])) {
-            \wc_add_notice(__('Character not found. Select character and try again.', 'woocommerce'), 'error');
-            return false;
-        }
-
         if (in_array('acore_char_sel', self::$skuList[$activeSku])) {
-            $guid = intval($_REQUEST['acore_char_sel']);
+            $guid = intval($_REQUEST['acore_char_sel'] ?? 0);
 
             if ($guid === 0) {
-                \wc_add_notice(__('No selected character', 'acore-wp-plugin'), 'error');
+                \wc_add_notice(__('No character selected. Please select a character and try again.', 'acore-wp-plugin'), 'error');
                 return false;
             }
 


### PR DESCRIPTION
- Fixes the regression brought by #131 where services without character selection would return an error when added to the cart (carbon copy tickets for instance).
- This PR uses a null coalescing operator to prevent the `undefined array key` warning, which was probably the intent of #131, without the need for an additional `if`.
- Slightly reworded the error message.