### PR TITLE
fix(docker-compose): update mysqld command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   wp-db:
     restart: unless-stopped
     image: mysql:8
-    command: 'mysqld --default-authentication-plugin=mysql_native_password'
+    command: 'mysqld --mysql-native-password=ON'
     volumes:
       - mysql-data:/var/lib/mysql
       - ./data:/data/


### PR DESCRIPTION
Since the image version isn't pinned, the Docker setup doesn't work anymore with the latest `mysql:8` image.
See https://stackoverflow.com/a/78447221