### PR TITLE
Updated RealmSettings.php

### DIFF
--- a/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/AdminPanel/Pages/RealmSettings.php
+++ b/srv/wordpress/wp-content/plugins/acore-wp-plugin/src/Components/AdminPanel/Pages/RealmSettings.php
@@ -1,16 +1,10 @@
 <?php
-
-use ACore\Manager\Opts;
+    use ACore\Manager\Opts;
 ?>
 
 <div class="wrap">
     <h2><?= __('AzerothCore Settings', Opts::I()->page_alias) ?></h2>
     <p>Configure realm name and database connection.</p>
-    <div class="alert alert-warning" role="alert">
-        Each field includes a placeholder, which must be replaced before using the SOAP connection or other plugin features. 
-        Hit the Save changes button after you filled in all the fields.
-        The default values are the suggestions based on the default azerothcore docker setup.
-    </div>
     <form name="form-acore-settings" method="post" action="">
         <div class="card w-50 p-0">
             <div class="card-body">
@@ -22,95 +16,54 @@ use ACore\Manager\Opts;
                     <tbody>
                         <tr>
                             <th scope="row">
-                                <label for="acore_realm_alias">Realm Alias:</label>
+                                <label for="acore_realm_alias">Realm Name:</label>
                             </th>
                             <td>
-                                <input type="text" name="acore_realm_alias" value="<?= Opts::I()->acore_realm_alias ?>" placeholder="AzerothCore" size="20">
+                                <input type="text" name="acore_realm_alias" value="<?= Opts::I()->acore_realm_alias; ?>" size="20" placeholder="AzerothCore">
                             </td>
                         </tr>
                     </tbody>
+                    
                 </table>
+                <p>
+                    <a href="https://www.azerothcore.org/wiki/remote-access">First time using SOAP? Click me!</a>
+                </p>
                 <hr />
                 <table class="form-table table table-borderless" role="presentation">
+                <h5>
+                    SOAP Settings
+                </h5>
                     <tbody>
                         <tr>
                             <th scope="row">
-                                <label for="acore_soap_host">Soap Host:</label>
+                                <label for="acore_soap_host">IPv4:</label>
                             </th>
                             <td>
-                                <input type="text" name="acore_soap_host" value="<?= Opts::I()->acore_soap_host ?>" placeholder="ac-worldserver" size="20">
+                                <input type="text" name="acore_soap_host" value="<?= Opts::I()->acore_soap_host; ?>" size="20" placeholder="127.0.0.1">
                             </td>
                         </tr>
                         <tr>
                             <th>
-                                <label for="acore_soap_port">Soap Port:</label>
+                                <label for="acore_soap_port">Port:</label>
                             </th>
                             <td>
-                                <input type="text" name="acore_soap_port" value="<?= Opts::I()->acore_soap_port ?>" placeholder="7878" size="20">
+                                <input type="text" name="acore_soap_port" value="<?= Opts::I()->acore_soap_port; ?>" size="20" placeholder="7878">
                             </td>
                         </tr>
                         <tr>
                             <th>
-                                <label for="acore_soap_user">Soap User:</label>
+                                <label for="acore_soap_user">Username:</label>
                             </th>
                             <td>
-                                <input type="text" name="acore_soap_user" value="<?= Opts::I()->acore_soap_user ?>" placeholder="admin" size="20">
+                                <input type="text" name="acore_soap_user" value="<?= Opts::I()->acore_soap_user; ?>" size="20" >
                             </td>
                         </tr>
                         <tr>
                             <th>
-                                <label for="acore_realm_alias">Soap Pass:</label>
+                                <label for="acore_realm_alias">Password:</label>
                             </th>
                             <td>
-                                <input type="password" name="acore_soap_pass" value="<?= Opts::I()->acore_soap_pass ?>" placeholder="admin" size="20">
-                            </td>
-                        </tr>
-                        <tr>
-                    </tbody>
-                </table>
-
-                <hr />
-
-                <table class="form-table table table-borderless" role="presentation">
-                    <tbody>
-                        <tr>
-                            <th scope="row">
-                                <label for="acore_db_auth_host">Database Auth Host:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_auth_host" value="<?= Opts::I()->acore_db_auth_host; ?>" placeholder="ac-database" size="20">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_db_auth_port">Database Auth Port:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_auth_port" value="<?= Opts::I()->acore_db_auth_port; ?>" placeholder="3306" size="20">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_db_auth_user">Database Auth User:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_auth_user" value="<?= Opts::I()->acore_db_auth_user; ?>" placeholder="root" size="20">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_realm_alias">Database Auth Pass:</label>
-                            </th>
-                            <td>
-                                <input type="password" name="acore_db_auth_pass" value="<?= Opts::I()->acore_db_auth_pass; ?>" placeholder="password" size="20">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_db_auth_name">Database Auth Name:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_auth_name" value="<?= Opts::I()->acore_db_auth_name; ?>" placeholder="acore_auth" size="20">
+                                <input type="password" name="acore_soap_pass" value="<?= Opts::I()->acore_soap_pass; ?>" size="20" >
                             </td>
                         </tr>
                         <tr>
@@ -120,45 +73,48 @@ use ACore\Manager\Opts;
                 <hr />
 
                 <table class="form-table table table-borderless" role="presentation">
+                <h5>
+                    Database: Auth
+                </h5>
                     <tbody>
                         <tr>
                             <th scope="row">
-                                <label for="acore_db_char_host">Database Characters Host:</label>
+                            <label for="acore_db_auth_host">IPv4:</label>
                             </th>
                             <td>
-                                <input type="text" name="acore_db_char_host" value="<?= Opts::I()->acore_db_char_host; ?>" placeholder="ac-database" size="20">
+                                <input type="text" name="acore_db_auth_host" value="<?= Opts::I()->acore_db_auth_host; ?>" size="20" placeholder="127.0.0.1">
                             </td>
                         </tr>
                         <tr>
                             <th>
-                                <label for="acore_db_char_port">Database Characters Port:</label>
+                                <label for="acore_db_auth_port">Port:</label>
                             </th>
                             <td>
-                                <input type="text" name="acore_db_char_port" value="<?= Opts::I()->acore_db_char_port; ?>" placeholder="3306" size="20">
+                                <input type="text" name="acore_db_auth_port" value="<?= Opts::I()->acore_db_auth_port; ?>" size="20" placeholder="3306">
                             </td>
                         </tr>
                         <tr>
                             <th>
-                                <label for="acore_db_char_user">Database Characters User:</label>
+                                <label for="acore_db_auth_user">Username:</label>
                             </th>
                             <td>
-                                <input type="text" name="acore_db_char_user" value="<?= Opts::I()->acore_db_char_user; ?>" placeholder="root" size="20">
+                                <input type="text" name="acore_db_auth_user" value="<?= Opts::I()->acore_db_auth_user; ?>" size="20" placeholder="acore">
                             </td>
                         </tr>
                         <tr>
                             <th>
-                                <label for="acore_realm_alias">Database Characters Pass:</label>
+                                <label for="acore_realm_alias">Password:</label>
                             </th>
                             <td>
-                                <input type="password" name="acore_db_char_pass" value="<?= Opts::I()->acore_db_char_pass; ?>" placeholder="password" size="20">
+                                <input type="password" name="acore_db_auth_pass" value="<?= Opts::I()->acore_db_auth_pass; ?>" size="20" placeholder="acore">
                             </td>
                         </tr>
                         <tr>
                             <th>
-                                <label for="acore_db_char_name">Database Characters Name:</label>
+                                <label for="acore_db_auth_name">Database Name:</label>
                             </th>
                             <td>
-                                <input type="text" name="acore_db_char_name" value="<?= Opts::I()->acore_db_char_name; ?>" placeholder="acore_characters" size="20">
+                                <input type="text" name="acore_db_auth_name" value="<?= Opts::I()->acore_db_auth_name; ?>" size="20" placeholder="acore_auth">
                             </td>
                         </tr>
                         <tr>
@@ -168,45 +124,99 @@ use ACore\Manager\Opts;
                 <hr />
 
                 <table class="form-table table table-borderless" role="presentation">
+                <h5>
+                    Database: Characters
+                </h5>
                     <tbody>
                         <tr>
                             <th scope="row">
-                                <label for="acore_db_world_host">Database World Host:</label>
+                                <label for="acore_db_char_host">IPv4:</label>
                             </th>
                             <td>
-                                <input type="text" name="acore_db_world_host" value="<?= Opts::I()->acore_db_world_host; ?>" placeholder="ac-database" size="20">
+                                <input type="text" name="acore_db_char_host" value="<?= Opts::I()->acore_db_char_host; ?>" size="20" placeholder="127.0.0.1">
                             </td>
                         </tr>
                         <tr>
                             <th>
-                                <label for="acore_db_world_port">Database World Port:</label>
+                                <label for="acore_db_char_port">Port:</label>
                             </th>
                             <td>
-                                <input type="text" name="acore_db_world_port" value="<?= Opts::I()->acore_db_world_port; ?>" placeholder="3306" size="20">
+                                <input type="text" name="acore_db_char_port" value="<?= Opts::I()->acore_db_char_port; ?>" size="20" placeholder="3306">
                             </td>
                         </tr>
                         <tr>
                             <th>
-                                <label for="acore_db_world_user">Database World User:</label>
+                                <label for="acore_db_char_user">Username:</label>
                             </th>
                             <td>
-                                <input type="text" name="acore_db_world_user" value="<?= Opts::I()->acore_db_world_user; ?>" placeholder="root" size="20">
+                                <input type="text" name="acore_db_char_user" value="<?= Opts::I()->acore_db_char_user; ?>" size="20" placeholder="acore">
                             </td>
                         </tr>
                         <tr>
                             <th>
-                                <label for="acore_realm_alias">Database World Pass:</label>
+                                <label for="acore_realm_alias">Password:</label>
                             </th>
                             <td>
-                                <input type="password" name="acore_db_world_pass" value="<?= Opts::I()->acore_db_world_pass; ?>" placeholder="password" size="20">
+                                <input type="password" name="acore_db_char_pass" value="<?= Opts::I()->acore_db_char_pass; ?>" size="20" placeholder="acore">
                             </td>
                         </tr>
                         <tr>
                             <th>
-                                <label for="acore_db_world_name">Database World Name:</label>
+                                <label for="acore_db_char_name">Database Name:</label>
                             </th>
                             <td>
-                                <input type="text" name="acore_db_world_name" value="<?= Opts::I()->acore_db_world_name; ?>" placeholder="acore_world" size="20">
+                                <input type="text" name="acore_db_char_name" value="<?= Opts::I()->acore_db_char_name; ?>" size="20" placeholder="acore_characters">
+                            </td>
+                        </tr>
+                        <tr>
+                    </tbody>
+                </table>
+
+            <hr />
+
+                <table class="form-table table table-borderless" role="presentation">
+                <h5>
+                    Database: World
+                </h5>
+                    <tbody>
+                        <tr>
+                            <th scope="row">
+                            <label for="acore_db_world_host">IPv4:</label>
+                            </th>
+                            <td>
+                                <input type="text" name="acore_db_world_host" value="<?= Opts::I()->acore_db_world_host; ?>" size="20" placeholder="127.0.0.1">
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>
+                                <label for="acore_db_world_port">Port:</label>
+                            </th>
+                            <td>
+                                <input type="text" name="acore_db_world_port" value="<?= Opts::I()->acore_db_world_port; ?>" size="20" placeholder="3306">
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>
+                                <label for="acore_db_world_user">Username:</label>
+                            </th>
+                            <td>
+                                <input type="text" name="acore_db_world_user" value="<?= Opts::I()->acore_db_world_user; ?>" size="20" placeholder="acore">
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>
+                                <label for="acore_realm_alias">Password:</label>
+                            </th>
+                            <td>
+                                <input type="password" name="acore_db_world_pass" value="<?= Opts::I()->acore_db_world_pass; ?>" size="20" placeholder="acore">
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>
+                                <label for="acore_db_world_name">Database Name:</label>
+                            </th>
+                            <td>
+                                <input type="text" name="acore_db_world_name" value="<?= Opts::I()->acore_db_world_name; ?>" size="20" placeholder="acore_world">
                             </td>
                         </tr>
                         <tr>
@@ -221,6 +231,9 @@ use ACore\Manager\Opts;
             <input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e('Save Changes', Opts::I()->page_alias) ?>" />
             <input type="button" name="check-soap" id="check-soap" class="button-secondary" value="<?php esc_attr_e('Check SOAP', Opts::I()->page_alias) ?>" />
         </p>
+        <h6>
+            You will need to "Save Changes" above before checking your SOAP Configuration!
+        </h6>
 
     </form>
 </div>


### PR DESCRIPTION
Added a Placeholder for any Input that would have a "default" value related to AzerothCore's Source.

Changed the each table's text to be easier to understand to anyone.

Added a note in the bottom about saving before checking the soap.

Added a link on the top (below realm name) for anyone who may be using soap for the first time.

Using placeholders as a reference for the person using the forms.

I noticed in my commit i somehow removed an "alert" but I dont recall removing anything while changing the text around.