### PR TITLE
fix: initial setup

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -13,3 +13,4 @@
 # DOCKER_CONF_NGINX_PATH=./conf/dist/nginx-conf
 # DOCKER_CONF_CERTS_PATH=./conf/dist/certs/
 # DOCKER_CONF_PHP_PATH=./conf/dist/php-conf/upload.ini
+# DOCKER_AC_NETWORK_EXTERNAL=true

--- a/data/docker/Wordpress.Dockerfile
+++ b/data/docker/Wordpress.Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:6-fpm
+FROM wordpress:6-php7.4-fpm
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   wp-db:
     restart: unless-stopped
@@ -37,7 +35,8 @@ services:
         USER_ID: ${DOCKER_USER_ID:-1000}
         GROUP_ID: ${DOCKER_GROUP_ID:-1000}
     depends_on:
-      - wp-db
+      wp-db:
+        condition: service_healthy
     working_dir: "/var/www/html"
     volumes:
       - type: bind
@@ -98,7 +97,7 @@ networks:
     driver: bridge
   ac-network:
     name: azerothcore-wotlk_ac-network # default network name if you use the docker setup of ac
-    external: true
+    external: ${DOCKER_AC_NETWORK_EXTERNAL:-true}
 volumes:
   mysql-data:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ networks:
     driver: bridge
   ac-network:
     name: azerothcore-wotlk_ac-network # default network name if you use the docker setup of ac
-    external: ${DOCKER_AC_NETWORK_EXTERNAL:-true}
+    external: ${DOCKER_AC_NETWORK_EXTERNAL:-false}
 volumes:
   mysql-data:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,8 +62,10 @@ More info about docker-configuration are available below
 
 ### AzerothCore integration
 
-ACore CMS is designed to work with AzerothCore. The ac-network included in our docker-compose file is a network that connects the AzerothCore server with the CMS. This network is flagged as external which means that you need an azerothcore server spinned up 
-using its own docker-compose file to make it work. If you are not using azerothcore with the docker-compose file provided by us, you can still running acore-cms with docker by setting DOCKER_AC_NETWORK_EXTERNAL to false in the .env file.
+ACore CMS is designed to work with AzerothCore. The ac-network included in our docker-compose file is a network that connects the AzerothCore server with the CMS. This network can be flagged as external which means that you need an azerothcore server spinned up using its own docker-compose file to make it work. 
+If you are using azerothcore with the docker-compose file provided by us, you can running acore-cms with docker by setting DOCKER_AC_NETWORK_EXTERNAL to true in the .env file.
+
+Please check this guide: [Connect the CMS to AcoreDocker and enable the shop](https://github.com/azerothcore/acore-cms/blob/master/docs/configure-acore-docker.md)
 
 ### CLI commands available
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,23 +29,16 @@ About **Nodejs & npm**, you can install it from [here](https://nodejs.org/en/).
 ### Docker container
 
 
-If you installed the requirements you are able to run the application using:
+If you installed the requirements, open your command prompt terminal (on Windows is for example PowerShell), navigate to the repository folder and issue the command:
+
 ```
-$ docker-compose up
+docker compose up
 ```
 
 It will download the related dependencies of the containers and start the acore-cms, next time you will need to just start the acore cms you can use:
 ```
 $ npm run docker:start
 ```
-
-Open your command prompt terminal (on Windows is for example PowerShell), navigate to the repository folder and issue the command:
-
-```
-docker-compose up
-```
-
-It will set up the docker container and download the necessary dependencies within.
 
 Now you can see the website in [http://localhost:80/](http://localhost:80/).
 
@@ -66,6 +59,11 @@ The env variables above are used to configure the ports within the docker-compos
 **WARNING: if you run this in production, comment the phpmyadmin section in docker-compose to not expose the phpmyadmin service to any user or change the mysql credentials**
 
 More info about docker-configuration are available below
+
+### AzerothCore integration
+
+ACore CMS is designed to work with AzerothCore. The ac-network included in our docker-compose file is a network that connects the AzerothCore server with the CMS. This network is flagged as external which means that you need an azerothcore server spinned up 
+using its own docker-compose file to make it work. If you are not using azerothcore with the docker-compose file provided by us, you can still running acore-cms with docker by setting DOCKER_AC_NETWORK_EXTERNAL to false in the .env file.
 
 ### CLI commands available
 

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
     ],
     "license": "AGPL3",
     "scripts": {
-        "docker:start": "docker-compose up",
-        "docker:start:d": "docker-compose up -d",
-        "docker:shell": "docker-compose exec php bash",
-        "docker:remove": "docker-compose down -rmi",
-        "docker:stop": "docker-compose stop",
-        "docker:logs": "docker-compose logs --tail=200 --follow",
-        "docker:db:export": "docker-compose up -d wp-db && docker-compose exec wp-db /apps/db_exporter/db_export.sh",
-        "docker:db:import": "docker-compose up -d wp-db && docker-compose exec wp-db /apps/db_exporter/db_import.sh"
+        "docker:start": "docker compose up",
+        "docker:start:d": "docker compose up -d",
+        "docker:shell": "docker compose exec php bash",
+        "docker:remove": "docker compose down -rmi",
+        "docker:stop": "docker compose stop",
+        "docker:logs": "docker compose logs --tail=200 --follow",
+        "docker:db:export": "docker compose up -d wp-db && docker compose exec wp-db /apps/db_exporter/db_export.sh",
+        "docker:db:import": "docker compose up -d wp-db && docker compose exec wp-db /apps/db_exporter/db_import.sh"
     },
     "devDependencies": {
         "@types/node": "^14.0.13"


### PR DESCRIPTION
## Changes

- fixed php version to use the one supported by the current pre-installed wordpress version (we will update it later)
- fixed healthcheck for wp-db
- Improved the readme
- switched from the legacy docker-compose to the new `docker compose` command
- implemented the DOCKER_AC_NETWORK_EXTERNAL to support installation of acore-cms when azerothcore is not under docker