### PR TITLE
feat: enhance plugin management with external configuration support 

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -22,7 +22,9 @@
 # DOCKER_HTTPS_PORTS=443:443
 # DOCKER_CONF_NGINX_PATH=./conf/dist/nginx-conf
 # DOCKER_CONF_CERTS_PATH=./conf/dist/certs/
-# DOCKER_CONF_PHP_PATH=./conf/dist/php-conf/upload.ini
+# DOCKER_CONF_PHP_PATH=./conf/upload.ini
+# DOCKER_CONF_INIT_PATH=./conf/init/
+
 # DOCKER_WORDPRESS_MULTISITE_USE_SUBDOMAINS=false
 # DOCKER_PHP_RESTART=unless-stopped
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 
 /conf/*
 !/conf/dist
+!/conf/init
+/conf/init/*
+!/data/plugins
+/data/plugins/*
 
 /docker-compose.*.yml
 !docker-compose.default.yml
@@ -94,4 +98,6 @@ package-lock.json
 #
 
 data/sql
+
+!.gitkeep
 

--- a/apps/init/init.lib.sh
+++ b/apps/init/init.lib.sh
@@ -9,13 +9,24 @@ is_plugin_installed() {
 # Function to install and activate a plugin if not already installed
 install_and_activate_plugin() {
     local plugin_name="$1"
-    local plugin_slug="$2"
+    local plugin_source="$2"
 
-    if ! is_plugin_installed "$plugin_slug"; then
-        echo "Installing and activating plugin: $plugin_name..."
-        wp plugin install "$plugin_slug" --activate --allow-root
+    # Extract plugin slug from source for checking installation
+    # For URLs and file paths, we need to get the actual plugin slug after installation
+    local plugin_slug="$plugin_source"
+    
+    # If it's a URL or file path, we'll check after installation
+    if [[ "$plugin_source" == http* ]] || [[ "$plugin_source" == /* ]]; then
+        echo "Installing and activating plugin: $plugin_name from $plugin_source..."
+        wp plugin install "$plugin_source" --activate --allow-root
     else
-        echo "Plugin $plugin_name is already installed."
+        # It's a WordPress repository slug
+        if ! is_plugin_installed "$plugin_slug"; then
+            echo "Installing and activating plugin: $plugin_name..."
+            wp plugin install "$plugin_slug" --activate --allow-root
+        else
+            echo "Plugin $plugin_name is already installed."
+        fi
     fi
 }
 

--- a/apps/init/init.lib.sh
+++ b/apps/init/init.lib.sh
@@ -14,43 +14,35 @@ is_theme_installed() {
 # Function to install and activate a plugin if not already installed
 install_and_activate_plugin() {
     local plugin_name="$1"
-    local plugin_source="$2"
+    local plugin_slug="$2"
+    local plugin_source="$3"
 
-    # Extract plugin slug from source for checking installation
-    # For URLs and file paths, we need to get the actual plugin slug after installation
-    local plugin_slug="$plugin_source"
+    if [ -z "$plugin_source" ]; then
+        plugin_source=$plugin_slug
+    fi
     
-    # If it's a URL or file path, we'll check after installation
-    if [[ "$plugin_source" == http* ]] || [[ "$plugin_source" == /* ]]; then
-        echo "Installing and activating plugin: $plugin_name from $plugin_source..."
+    if ! is_plugin_installed "$plugin_slug"; then
+        echo "Installing and activating plugin: $plugin_name..."
         wp plugin install "$plugin_source" --activate --allow-root
     else
-        # It's a WordPress repository slug
-        if ! is_plugin_installed "$plugin_slug"; then
-            echo "Installing and activating plugin: $plugin_name..."
-            wp plugin install "$plugin_slug" --activate --allow-root
-        else
-            echo "Plugin $plugin_name is already installed."
-        fi
+        echo "Plugin $plugin_name is already installed."
     fi
 }
 
 install_and_activate_theme() {
     local theme_name="$1"
-    local theme_source="$2"
+    local theme_slug="$2"
+    local theme_source="$3"
+
+    if [ -z "$theme_source" ]; then
+        theme_source=$theme_slug
+    fi
 
     echo "Installing and activating theme: $theme_name from $theme_source..."
-
-    if [[ "$theme_source" == http* ]] || [[ "$theme_source" == /* ]]; then
-        # If it's a URL or file path, install it directly
+    if ! is_theme_installed "$theme_slug"; then
         wp theme install "$theme_source" --activate --allow-root
     else
-        # It's a WordPress repository slug
-        if ! is_theme_installed "$theme_source"; then
-            wp theme install "$theme_source" --activate --allow-root
-        else
-            echo "Theme $theme_name is already installed."
-        fi
+        echo "Theme $theme_name is already installed."
     fi
 }
 

--- a/apps/init/init.lib.sh
+++ b/apps/init/init.lib.sh
@@ -6,6 +6,11 @@ is_plugin_installed() {
     return $?
 }
 
+is_theme_installed() {
+    wp theme is-installed "$1" --allow-root
+    return $?
+}
+
 # Function to install and activate a plugin if not already installed
 install_and_activate_plugin() {
     local plugin_name="$1"
@@ -26,6 +31,25 @@ install_and_activate_plugin() {
             wp plugin install "$plugin_slug" --activate --allow-root
         else
             echo "Plugin $plugin_name is already installed."
+        fi
+    fi
+}
+
+install_and_activate_theme() {
+    local theme_name="$1"
+    local theme_source="$2"
+
+    echo "Installing and activating theme: $theme_name from $theme_source..."
+
+    if [[ "$theme_source" == http* ]] || [[ "$theme_source" == /* ]]; then
+        # If it's a URL or file path, install it directly
+        wp theme install "$theme_source" --activate --allow-root
+    else
+        # It's a WordPress repository slug
+        if ! is_theme_installed "$theme_source"; then
+            wp theme install "$theme_source" --activate --allow-root
+        else
+            echo "Theme $theme_name is already installed."
         fi
     fi
 }

--- a/apps/init/init.sh
+++ b/apps/init/init.sh
@@ -20,6 +20,11 @@ plugins_install=(
     "Advanced Custom Fields|advanced-custom-fields"
 )
 
+# List of themes to install
+# Format: "Theme Name|theme-source"
+# Source can be: slug (from WP repo), URL, or file path
+themes_install=()
+
 # List of plugins to activate only once (already present in container)
 plugins_activate_only=(
     "ACore WP Plugins|acore-wp-plugins"
@@ -85,7 +90,7 @@ fi
 wp maintenance-mode activate --allow-root || echo "Maintenance mode already activated or failed to activate."
 
 # Install and activate plugins
-echo "Installing and activating plugins..."
+echo "Installing and activating plugins & themes..."
 
 source "$CURPATH/init.lib.sh"
 
@@ -96,6 +101,13 @@ for plugin in "${plugins_install[@]}"; do
     
     echo "Installing $plugin_name ($plugin_source)..."
     install_and_activate_plugin "$plugin_name" "$plugin_source"
+done
+
+# Install themes if any
+for theme in "${themes_install[@]}"; do
+    IFS='|' read -r theme_name theme_source <<< "$theme"
+    echo "Installing theme $theme_name ($theme_source)..."
+    install_and_activate_theme "$theme_name" "$theme_source"
 done
 
 # Handle Acore WP Plugins activation

--- a/apps/init/init.sh
+++ b/apps/init/init.sh
@@ -97,23 +97,23 @@ source "$CURPATH/init.lib.sh"
 # Install and activate each plugin in the list
 for plugin in "${plugins_install[@]}"; do
     # Split plugin name and source
-    IFS='|' read -r plugin_name plugin_source <<< "$plugin"
+    IFS='|' read -r plugin_name plugin_slug plugin_source <<< "$plugin"
     
     echo "Installing $plugin_name ($plugin_source)..."
-    install_and_activate_plugin "$plugin_name" "$plugin_source"
+    install_and_activate_plugin "$plugin_name" "$plugin_slug" "$plugin_source"
 done
 
 # Install themes if any
 for theme in "${themes_install[@]}"; do
-    IFS='|' read -r theme_name theme_source <<< "$theme"
+    IFS='|' read -r theme_name theme_slug theme_source <<< "$theme"
     echo "Installing theme $theme_name ($theme_source)..."
-    install_and_activate_theme "$theme_name" "$theme_source"
+    install_and_activate_theme "$theme_name" "$theme_slug" "$theme_source"
 done
 
 # Handle Acore WP Plugins activation
 for plugin in "${plugins_activate_only[@]}"; do
     IFS='|' read -r plugin_name plugin_slug <<< "$plugin"
-    
+
     echo "Activating $plugin_name ($plugin_slug) only once..."
     handle_plugin_activation_once "$plugin_slug"
 done

--- a/apps/init/init.sh
+++ b/apps/init/init.sh
@@ -82,7 +82,7 @@ if ! wp core is-installed --allow-root; then
     fi
 fi
 
-wp maintenance-mode activate --allow-root
+wp maintenance-mode activate --allow-root || echo "Maintenance mode already activated or failed to activate."
 
 # Install and activate plugins
 echo "Installing and activating plugins..."

--- a/conf/init/.gitkeep
+++ b/conf/init/.gitkeep
@@ -1,0 +1,2 @@
+# This directory is for external plugin configurations
+# Third-party projects can mount their plugin configuration files here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - ./src/acore-wp-plugin:/var/www/html/wp-content/plugins/acore-wp-plugins
       - ${DOCKER_WORDPRESS_SRC_PATH:-wordpress-src}:/var/www/html
       - ./apps/init/:/usr/local/bin/acore-init/
+      - ${DOCKER_CONF_INIT_PATH:-./conf/init}:/conf/init:ro
     env_file:
       # environment variables are retrieved by this file
       # NOTE: you can add more variables to the .env file but
@@ -96,6 +97,7 @@ services:
     volumes:
       - ${DOCKER_CONF_NGINX_PATH:-./conf/dist/nginx-conf}:/etc/nginx/conf.d/
       - ${DOCKER_CONF_CERTS_PATH:-./conf/dist/certs/}:/etc/nginx/certs/
+      - ${DOCKER_CONF_CERTS_PATH:-./data/plugins/}:/tmp/plugins
       - ./var/logs:/var/log/nginx
       - ${DOCKER_WORDPRESS_SRC_PATH:-wordpress-src}:/var/www/html:ro
     extra_hosts:

--- a/docs/README.md
+++ b/docs/README.md
@@ -216,15 +216,15 @@ NOTE: by default sql files will be exported inside the /data/sql folder
 
 If you want to install the acore-wp-plugin as a standalone plugin, you can follow the instructions in the [acore-wp-plugin repository](https://github.com/azerothcore/acore-cms-wp-plugin).
 
-## Plugin Configuration System (Docker only)
+## Plugin and Theme Configuration System (Docker only)
 
-ACore CMS includes a flexible plugin configuration system that allows you to install WordPress plugins with a docker initialization scripts (you can find it in the `/apps/init` directory).
+ACore CMS includes a flexible configuration system that allows you to install WordPress plugins and themes with docker initialization scripts (you can find them in the `/apps/init` directory).
 
 ### Configuration Directory
 
-External plugin configurations are loaded from the `/conf/init/` directory, which can be mounted from your host system. This directory should contain `.conf` files that define which plugins to install and activate.
+External configurations are loaded from the `/conf/init/` directory, which can be mounted from your host system. This directory should contain `.conf` files that define which plugins and themes to install and activate.
 
-### Plugin Configuration Format
+### Configuration Format
 
 Create `.conf` files in your `conf/init/` directory with the following format:
 
@@ -240,34 +240,46 @@ plugins_install+=(
     "Local Plugin|/tmp/plugins/local-plugin.zip"
 )
 
+# Add themes to install and activate
+# Format: "Theme Name|theme-source"
+# Source can be: slug (from WP repo), URL, or file path
+themes_install+=(
+    "Twenty Twenty-One|twentytwentyone"
+    "Custom Theme|https://example.com/theme.zip"
+    "Local Theme|/tmp/themes/local-theme.zip"
+)
+
 # Add plugins to activate only (already present in container)
 plugins_activate_only+=(
     "Existing Plugin|existing-plugin-slug"
 )
 ```
 
-### Plugin Sources
+### Sources
 
-The system supports multiple plugin sources:
+The system supports multiple sources for plugins and themes:
 
-1. **WordPress Repository**: Use the plugin slug
+1. **WordPress Repository**: Use the slug
    ```bash
    plugins_install+=("WooCommerce|woocommerce")
+   themes_install+=("Twenty Twenty-One|twentytwentyone")
    ```
 
 2. **URLs**: Direct download links to zip files
    ```bash
    plugins_install+=("Plugin Name|https://releases.example.com/plugin.zip")
+   themes_install+=("Theme Name|https://releases.example.com/theme.zip")
    ```
 
 3. **Local Files**: Zip files mounted into the container
    ```bash
    plugins_install+=("Local Plugin|/tmp/plugins/local-plugin.zip")
+   themes_install+=("Local Theme|/tmp/themes/local-theme.zip")
    ```
 
 ### Local zip files
 
-You can place your plugin zip file in the `/data/plugins/` folder (which is mounted as `/tmp/plugins` in the container) and reference it in your configuration:
+You can place your plugin or theme zip files in the `/data/plugins/` or `/data/themes/` folders (which are mounted as `/tmp/plugins` and `/tmp/themes` in the container) and reference them in your configuration:
 
 ```bash
 #!/bin/bash
@@ -277,17 +289,17 @@ plugins_install+=(
     "Local Plugin|/tmp/plugins/local-plugin.zip"
 )
 
+themes_install+=(
+    "Custom Theme|https://example.com/theme.zip"
+    "Local Theme|/tmp/themes/local-theme.zip"
+)
 ```
 
-### Default Plugins
+### Default Plugins and Themes
 
-ACore CMS comes with a default set of plugins that are always installed:
-- WooCommerce
-- WPGraphQL
-- WPGraphQL ACF
-- myCred
-- Advanced Custom Fields
-- ACore WP Plugins (activation only)
+ACore CMS comes with a default set of plugins and themes that are always installed:
+- Plugins: WooCommerce, WPGraphQL, WPGraphQL ACF, myCred, Advanced Custom Fields, ACore WP Plugins (activation only)
+- Themes: None by default
 
-External configurations add to or can override these defaults by modifying the `plugins_install` and `plugins_activate_only` arrays.
+External configurations add to or can override these defaults by modifying the `plugins_install`, `themes_install`, and `plugins_activate_only` arrays.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -236,8 +236,8 @@ Create `.conf` files in your `conf/init/` directory with the following format:
 # Source can be: slug (from WP repo), URL, or file path
 plugins_install+=(
     "WooCommerce|woocommerce"
-    "Custom Plugin|https://example.com/plugin.zip"
-    "Local Plugin|/tmp/plugins/local-plugin.zip"
+    "Custom Plugin|custom-plugin|https://example.com/plugin.zip"
+    "Local Plugin|local-plugin|/tmp/plugins/local-plugin.zip"
 )
 
 # Add themes to install and activate
@@ -245,8 +245,8 @@ plugins_install+=(
 # Source can be: slug (from WP repo), URL, or file path
 themes_install+=(
     "Twenty Twenty-One|twentytwentyone"
-    "Custom Theme|https://example.com/theme.zip"
-    "Local Theme|/tmp/themes/local-theme.zip"
+    "Custom Theme|custom-theme|https://example.com/theme.zip"
+    "Local Theme|local-theme|/tmp/themes/local-theme.zip"
 )
 
 # Add plugins to activate only (already present in container)
@@ -267,14 +267,14 @@ The system supports multiple sources for plugins and themes:
 
 2. **URLs**: Direct download links to zip files
    ```bash
-   plugins_install+=("Plugin Name|https://releases.example.com/plugin.zip")
-   themes_install+=("Theme Name|https://releases.example.com/theme.zip")
+   plugins_install+=("Plugin Name|plugin-slug|https://releases.example.com/plugin.zip")
+   themes_install+=("Theme Name|theme-slug|https://releases.example.com/theme.zip")
    ```
 
 3. **Local Files**: Zip files mounted into the container
    ```bash
-   plugins_install+=("Local Plugin|/tmp/plugins/local-plugin.zip")
-   themes_install+=("Local Theme|/tmp/themes/local-theme.zip")
+   plugins_install+=("Local Plugin|local-plugin|/tmp/plugins/local-plugin.zip")
+   themes_install+=("Local Theme|local-theme|/tmp/themes/local-theme.zip")
    ```
 
 ### Local zip files
@@ -285,13 +285,13 @@ You can place your plugin or theme zip files in the `/data/plugins/` or `/data/t
 #!/bin/bash
 
 plugins_install+=(
-    "Custom Plugin|https://example.com/plugin.zip"
-    "Local Plugin|/tmp/plugins/local-plugin.zip"
+    "Custom Plugin|custom-plugin|https://example.com/plugin.zip"
+    "Local Plugin|local-plugin|/tmp/plugins/local-plugin.zip"
 )
 
 themes_install+=(
-    "Custom Theme|https://example.com/theme.zip"
-    "Local Theme|/tmp/themes/local-theme.zip"
+    "Custom Theme|custom-theme|https://example.com/theme.zip"
+    "Local Theme|local-theme|/tmp/themes/local-theme.zip"
 )
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -216,4 +216,78 @@ NOTE: by default sql files will be exported inside the /data/sql folder
 
 If you want to install the acore-wp-plugin as a standalone plugin, you can follow the instructions in the [acore-wp-plugin repository](https://github.com/azerothcore/acore-cms-wp-plugin).
 
+## Plugin Configuration System (Docker only)
+
+ACore CMS includes a flexible plugin configuration system that allows you to install WordPress plugins with a docker initialization scripts (you can find it in the `/apps/init` directory).
+
+### Configuration Directory
+
+External plugin configurations are loaded from the `/conf/init/` directory, which can be mounted from your host system. This directory should contain `.conf` files that define which plugins to install and activate.
+
+### Plugin Configuration Format
+
+Create `.conf` files in your `conf/init/` directory with the following format:
+
+```bash
+#!/bin/bash
+
+# Add plugins to install and activate
+# Format: "Plugin Name|plugin-source"
+# Source can be: slug (from WP repo), URL, or file path
+plugins_install+=(
+    "WooCommerce|woocommerce"
+    "Custom Plugin|https://example.com/plugin.zip"
+    "Local Plugin|/tmp/plugins/local-plugin.zip"
+)
+
+# Add plugins to activate only (already present in container)
+plugins_activate_only+=(
+    "Existing Plugin|existing-plugin-slug"
+)
+```
+
+### Plugin Sources
+
+The system supports multiple plugin sources:
+
+1. **WordPress Repository**: Use the plugin slug
+   ```bash
+   plugins_install+=("WooCommerce|woocommerce")
+   ```
+
+2. **URLs**: Direct download links to zip files
+   ```bash
+   plugins_install+=("Plugin Name|https://releases.example.com/plugin.zip")
+   ```
+
+3. **Local Files**: Zip files mounted into the container
+   ```bash
+   plugins_install+=("Local Plugin|/tmp/plugins/local-plugin.zip")
+   ```
+
+### Local zip files
+
+You can place your plugin zip file in the `/data/plugins/` folder (which is mounted as `/tmp/plugins` in the container) and reference it in your configuration:
+
+```bash
+#!/bin/bash
+
+plugins_install+=(
+    "Custom Plugin|https://example.com/plugin.zip"
+    "Local Plugin|/tmp/plugins/local-plugin.zip"
+)
+
+```
+
+### Default Plugins
+
+ACore CMS comes with a default set of plugins that are always installed:
+- WooCommerce
+- WPGraphQL
+- WPGraphQL ACF
+- myCred
+- Advanced Custom Fields
+- ACore WP Plugins (activation only)
+
+External configurations add to or can override these defaults by modifying the `plugins_install` and `plugins_activate_only` arrays.
 


### PR DESCRIPTION
This pull request introduces a flexible plugin configuration system for WordPress installations using Docker, along with updates to the initialization scripts and documentation. The changes enhance plugin management by supporting multiple plugin sources, external configurations, and local file mounting.

### Plugin Management Enhancements:
* [`apps/init/init.lib.sh`](diffhunk://#diff-94c8c5a9b9bcdfc6d800aafaab42cf9003f8f9bced1cf5a3e4d0c11ccae75f9eL12-R30): Updated the `install_and_activate_plugin` function to support plugin installation from URLs and local file paths, in addition to WordPress repository slugs.
* [`apps/init/init.sh`](diffhunk://#diff-22a2102f98d3620fd1e987f7ae5546282021f3c511af646ba56d96c432ded90fL12-R14): Added support for loading external plugin configurations from a mounted directory (`/conf/init`) and updated the format for specifying plugins to install and activate. [[1]](diffhunk://#diff-22a2102f98d3620fd1e987f7ae5546282021f3c511af646ba56d96c432ded90fL12-R14) [[2]](diffhunk://#diff-22a2102f98d3620fd1e987f7ae5546282021f3c511af646ba56d96c432ded90fL22-R43) [[3]](diffhunk://#diff-22a2102f98d3620fd1e987f7ae5546282021f3c511af646ba56d96c432ded90fL77-R98)

### Docker Configuration Updates:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R52): Added new volume mounts for external plugin configurations (`/conf/init`) and local plugin zip files (`/data/plugins`). [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R52) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R100)

### Documentation Improvements:
* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R219-R292): Documented the new plugin configuration system, including details on supported plugin sources, configuration file format, and default plugins.

### Miscellaneous:
* [`conf/init/.gitkeep`](diffhunk://#diff-ad3035aa2a1f84269e2b56081054513fba0c1be927c667a11d3e88d61778bd6fR1-R2): Added a placeholder file to indicate the purpose of the `/conf/init` directory for external plugin configurations.