### PR TITLE
fix: 404 plugin files & docker logging

### DIFF
--- a/conf/dist/nginx-conf/wordpress.conf
+++ b/conf/dist/nginx-conf/wordpress.conf
@@ -1,3 +1,11 @@
+
+map $status $loggable
+{ 
+    ~^[2] 0;
+    ~^[3] 0;
+    default 1; 
+}
+
 server {
     listen 80;
     listen 443 ssl;
@@ -5,8 +13,8 @@ server {
     root /var/www/html;
     index index.php;
 
-    access_log /var/log/nginx/access.log;
-    error_log /var/log/nginx/error.log;
+    access_log /dev/stdout combined if=$loggable;
+    error_log /dev/stderr;
 
     client_max_body_size 128M;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,7 @@ services:
       - ${DOCKER_CONF_CERTS_PATH:-./data/plugins/}:/tmp/plugins
       - ./var/logs:/var/log/nginx
       - ${DOCKER_WORDPRESS_SRC_PATH:-wordpress-src}:/var/www/html:ro
+      - ./src/acore-wp-plugin:/var/www/html/wp-content/plugins/acore-wp-plugins
     extra_hosts:
       - "web.local:127.0.0.1"
     ports:


### PR DESCRIPTION
Plugin files were not properly loaded because the web.local container didn't have the volume for it

NOTE: nginx now also logs into /dev/stdout directly to make sure docker can catch its logs, also, we filter out non-error access logs