### PR TITLE
Do not allow smartstone skus to be added to cart without character selection

### DIFF
--- a/src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php
+++ b/src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php
@@ -38,7 +38,7 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
         }
 
         $current_user = wp_get_current_user();
-        if (!$current_user) {
+        if (!is_user_logged_in()) {
             \wc_add_notice(__('You must be logged in to buy it!', 'acore-wp-plugin'), 'error');
             return false;
         }


### PR DESCRIPTION
Current behavior (before this PR, as my mistake and lack of knowledge) smartstone can be added to cart without selecting a character (from the catologue of costumes or others from the smartstone), which leads people buying costumes and not getting them because there's no character associated. This fixes the current issue for the current implementation (for character unlock the service, if this get changed to account bound, we change smartstone impelemtnation then).

This will redirect them to the page (of "add cart") and ask them to select the character

This is hasn't be tested, and can't test it for now.

And i tried submitting this fix on the same night of invesgiating, I couldn't update `acore-cms` within my `chormiecraft-cms` in my WSL, lack of linux and git together maybe.