### PR TITLE
Addition "gift" into Smartstone Implementation

### DIFF
--- a/src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php
+++ b/src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php
@@ -20,7 +20,7 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
     }
 
     public static function init() {
-        add_action('woocommerce_after_add_to_cart_quantity', self::sprefix() . 'before_add_to_cart_button');
+        add_action('woocommerce_before_add_to_cart_button', self::sprefix() . 'before_add_to_cart_button');
         add_filter('woocommerce_add_cart_item_data', self::sprefix() . 'add_cart_item_data', 20, 3);
         add_filter('woocommerce_get_item_data', self::sprefix() . 'get_item_data', 20, 2);
         add_action('woocommerce_checkout_order_processed', self::sprefix() . 'checkout_order_processed', 20, 2);


### PR DESCRIPTION
- Now you able to gift costumes, combat pets or normal pets.
Requirements: That you're logged in, that you select a character to send from and a character to send to.

The title and body should start with $Character has sent you $item.

- This has not been tested.

Missing, as mentioned by randalf
<img width="842" height="257" alt="image" src="https://github.com/user-attachments/assets/8cc4762e-f8f3-403f-a854-63eada229efa" />
