### PR TITLE
fix(unstuck): revive character before teleporting home

### DIFF
--- a/src/acore-wp-plugin/src/Manager/Soap/UnstuckService.php
+++ b/src/acore-wp-plugin/src/Manager/Soap/UnstuckService.php
@@ -11,6 +11,7 @@ class UnstuckService
 
     public function unstuckByName($charName)
     {
+        $this->executeCommand(".revive $charName");
         return $this->executeCommand(".unstuck $charName");
     }
 }


### PR DESCRIPTION
## Summary

- Characters that are dead (ghosts) when unstuck would arrive at their home location still as ghosts
- Added a `.revive` SOAP command call before `.unstuck` so the character is alive on arrival
- Calling `.revive` on a character that is already alive is a no-op on the server side, so there is no downside

## Test plan

- [ ] Log in as a user with a dead/ghost character
- [ ] Use the unstuck page and confirm the character is teleported home **and** revived
- [ ] Use the unstuck page with a character that is already alive and confirm it still works normally