### PR TITLE
Use replica for admin PvP stats reads

### DIFF
--- a/src/acore-wp-plugin/src/Components/AdminPanel/SettingsController.php
+++ b/src/acore-wp-plugin/src/Components/AdminPanel/SettingsController.php
@@ -21,6 +21,28 @@ class SettingsController {
         $this->view = new SettingsView($this);
     }
 
+
+    private function getPvpStatsReplicaPdo(): \PDO {
+        return new \PDO(
+            'mysql:host=' . getenv('PVPSTATS_REPLICA_HOST') . ';port=' . getenv('PVPSTATS_REPLICA_PORT') . ';dbname=' . getenv('PVPSTATS_REPLICA_DB') . ';charset=utf8mb4',
+            getenv('PVPSTATS_REPLICA_USER'),
+            getenv('PVPSTATS_REPLICA_PASSWORD'),
+            [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+            ]
+        );
+    }
+
+    private function runPvpStatsReplicaQuery(string $query, array $params): array {
+        $stmt = $this->getPvpStatsReplicaPdo()->prepare($query);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue(':' . $key, $value);
+        }
+        $stmt->execute();
+        return $stmt->fetchAll();
+    }
+
     public function loadHome() {
         //must check that the user has the required capability
         if (!current_user_can('game_master')) {
@@ -212,12 +234,10 @@ class SettingsController {
                     $query .= " LIMIT $limitRewards";
                 }
 
-                $connection = ACoreServices::I()->getCharacterEm()->getConnection();
-                $queryResult = $connection->executeQuery(
+                $result = $this->runPvpStatsReplicaQuery(
                     $query,
                     array('winner' => $isWinner, 'month' => $month, 'year' => $year)
                 );
-                $result = $queryResult->fetchAllAssociative();
                 if ($result) {
                     $accountCounter = 0;
                     $pointsCounter = 0;
@@ -339,12 +359,10 @@ class SettingsController {
                 ORDER BY total_battle DESC
                 LIMIT 10";
 
-                $connection = ACoreServices::I()->getCharacterEm()->getConnection();
-                $queryResult = $connection->executeQuery(
+                $result = $this->runPvpStatsReplicaQuery(
                     $query,
                     array('isWinner' => $isWinner, 'month' => $month, 'year' => $year)
                 );
-                $result = $queryResult->fetchAllAssociative();
             }
 
             $data = [

--- a/src/acore-wp-plugin/src/Manager/ACoreServices.php
+++ b/src/acore-wp-plugin/src/Manager/ACoreServices.php
@@ -329,7 +329,6 @@ class ACoreServices
         $conn = $this->getAccountEm()->getConnection();
         $stmt = $conn->prepare($query);
         $stmt->bindValue(1, $user->get("user_login"));
-        $stmt->executeQuery();
         $res = $stmt->executeQuery();
         return $res->fetchOne();
     }
@@ -343,7 +342,6 @@ class ACoreServices
         $conn = $this->getAccountEm()->getConnection();
         $stmt = $conn->prepare($query);
         $stmt->bindValue(1, $user->get("user_login"));
-        $stmt->executeQuery();
         $res = $stmt->executeQuery();
         $row = $res->fetchAssociative();
         $total = isset($row["totaltime"]) ? (int) $row["totaltime"] : 0;
@@ -370,7 +368,6 @@ class ACoreServices
         $conn = $this->getAccountEm()->getConnection();
         $stmt = $conn->prepare($query);
         $stmt->bindValue(1, $id);
-        $stmt->executeQuery();
         $res = $stmt->executeQuery();
         return $res->fetchOne();
     }
@@ -383,7 +380,6 @@ class ACoreServices
         $conn = $this->getAccountEm()->getConnection();
         $stmt = $conn->prepare($query);
         $stmt->bindValue(1, $username);
-        $stmt->executeQuery();
         $res = $stmt->executeQuery();
         return $res->fetchOne();
     }
@@ -396,7 +392,6 @@ class ACoreServices
         $conn = $this->getAccountEm()->getConnection();
         $stmt = $conn->prepare($query);
         $stmt->bindValue(1, $usedId);
-        $stmt->executeQuery();
         $res = $stmt->executeQuery();
         return $res->fetchOne();
     }
@@ -409,7 +404,6 @@ class ACoreServices
         $conn = $this->getCharacterEm()->getConnection();
         $stmt = $conn->prepare($query);
         $stmt->bindValue(1, $character);
-        $stmt->executeQuery();
         $res = $stmt->executeQuery();
         return $res->fetchAllAssociative();
     }
@@ -427,7 +421,6 @@ class ACoreServices
         $conn = $this->getCharacterEm()->getConnection();
         $stmt = $conn->prepare($query);
         $stmt->bindValue(1, $guildLeaderGuid);
-        $stmt->executeQuery();
         $res = $stmt->executeQuery();
         return $res->fetchOne();
     }


### PR DESCRIPTION
## Summary
- route heavy admin-panel PvP stats read queries through a dedicated replica PDO connection
- keep reward/account writes on the normal live/write-capable path
- remove duplicate executeQuery calls in ACoreServices read helpers

## Validation
- php -l passed for SettingsController.php and ACoreServices.php on the production CT checkout before PR packaging