### PR TITLE
feat(smartstone): support account-wide unlocks (costumes, perks)

### DIFF
--- a/src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php
+++ b/src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php
@@ -19,7 +19,7 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
         }
         $parts = explode("_", $sku);
 
-        if (count($parts) < 3 || $parts[0] != "smartstone" || !is_numeric($parts[1]) || !is_numeric($parts[2])) {
+        if (count($parts) < 3 || $parts[0] !== "smartstone" || !is_numeric($parts[1]) || !is_numeric($parts[2])) {
             return false;
         }
 
@@ -51,16 +51,19 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
             return $passed;
         }
 
+        // Any product whose SKU claims to be a smartstone item requires the buyer to
+        // be logged in, regardless of whether the rest of the SKU parses cleanly.
+        // Fail closed on the login check before falling back to other validators.
+        if (!is_user_logged_in()) {
+            \wc_add_notice(__('You must be logged in to buy it!', 'acore-wp-plugin'), 'error');
+            return false;
+        }
+
         $parsed = self::getItemId($sku);
         if (!$parsed) {
             return $passed; // malformed SKU; let WooCommerce/other validators handle it
         }
         [$smartstone_category, $smartstone_id] = $parsed;
-
-        if (!is_user_logged_in()) {
-            \wc_add_notice(__('You must be logged in to buy it!', 'acore-wp-plugin'), 'error');
-            return false;
-        }
 
         // Account-wide services (costumes, perks) unlock via `.smartstone unlock account`
         // and do not need a character selection.

--- a/src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php
+++ b/src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php
@@ -6,17 +6,31 @@ use ACore\Manager\ACoreServices;
 
 class SmartstoneVanity extends \ACore\Lib\WpClass {
 
+    /**
+     * Service types (ActionType in mod-chromiecraft-smartstone src/Smartstone.h)
+     * that the server's `.smartstone unlock account` command will accept.
+     * These get unlocked account-wide and do NOT require a character selection.
+     */
+    const ACCOUNT_WIDE_CATEGORIES = [2 /* Costume */, 9 /* Perk */];
+
     private static function getItemId($sku) {
+        if (!is_string($sku) || $sku === '') {
+            return false;
+        }
         $parts = explode("_", $sku);
 
-        if ($parts[0] != "smartstone" || !is_numeric($parts[1]) || !is_numeric($parts[2])) {
+        if (count($parts) < 3 || $parts[0] != "smartstone" || !is_numeric($parts[1]) || !is_numeric($parts[2])) {
             return false;
         }
 
-        $smartstone_category = $parts[1];
-        $smartstone_id = $parts[2];
+        $smartstone_category = (int) $parts[1];
+        $smartstone_id = (int) $parts[2];
 
         return [$smartstone_category, $smartstone_id];
+    }
+
+    private static function isAccountWide($category) {
+        return in_array((int) $category, self::ACCOUNT_WIDE_CATEGORIES, true);
     }
 
     public static function init() {
@@ -29,7 +43,7 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
         add_action('woocommerce_add_to_cart_validation', [__CLASS__, 'add_to_cart_validation'], 10, 5);
     }
 
-     // Validator for add to cart from external sources (no character selected) or logged in required from "CartValidation")    
+     // Validator for add to cart from external sources (no character selected) or logged in required from "CartValidation")
     public static function add_to_cart_validation($passed, $product_id, $quantity, $variation_id = null, $variations = null) {
         $product = $variation_id ? \wc_get_product($variation_id) : \wc_get_product($product_id);
         $sku = $product->get_sku();
@@ -37,10 +51,21 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
             return $passed;
         }
 
-        $current_user = wp_get_current_user();
+        $parsed = self::getItemId($sku);
+        if (!$parsed) {
+            return $passed; // malformed SKU; let WooCommerce/other validators handle it
+        }
+        [$smartstone_category, $smartstone_id] = $parsed;
+
         if (!is_user_logged_in()) {
             \wc_add_notice(__('You must be logged in to buy it!', 'acore-wp-plugin'), 'error');
             return false;
+        }
+
+        // Account-wide services (costumes, perks) unlock via `.smartstone unlock account`
+        // and do not need a character selection.
+        if (self::isAccountWide($smartstone_category)) {
+            return $passed;
         }
 
         $guid = intval($_REQUEST['acore_char_sel'] ?? 0);
@@ -55,12 +80,18 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
     // LIST
     public static function before_add_to_cart_button() {
         global $product;
-        [$smartstone_category, $smartstone_id] = self::getItemId($product->get_sku());
-        if (!$smartstone_id) {
+        $parsed = self::getItemId($product->get_sku());
+        if (!$parsed) {
             return;
         }
+        [$smartstone_category, $smartstone_id] = $parsed;
 
         FieldElements::get3dViewer();
+
+        // Account-wide unlocks (costumes, perks) don't need a character selector.
+        if (self::isAccountWide($smartstone_category)) {
+            return;
+        }
 
         $current_user = wp_get_current_user();
 
@@ -74,12 +105,18 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
     // ( each cart item has their own data )
     public static function add_cart_item_data($cart_item_data, $product_id, $variation_id) {
         $product = $variation_id ? \wc_get_product($variation_id) : \wc_get_product($product_id);
-        [$smartstone_category, $smartstone_id] = self::getItemId($product->get_sku());
-        if (!$smartstone_id) {
+        $parsed = self::getItemId($product->get_sku());
+        if (!$parsed) {
             return $cart_item_data;
         }
+        [$smartstone_category, $smartstone_id] = $parsed;
 
-        if (isset($_REQUEST['acore_char_sel'])) {
+        if (self::isAccountWide($smartstone_category)) {
+            // No character selector for account-wide unlocks; still stash the SKU
+            // and force a unique line so the cart treats it as its own row.
+            $cart_item_data['acore_item_sku'] = $product->get_sku();
+            $cart_item_data['unique_key'] = md5(microtime() . rand());
+        } else if (isset($_REQUEST['acore_char_sel'])) {
             $cart_item_data['acore_char_sel'] = $_REQUEST['acore_char_sel'];
             $cart_item_data['acore_item_sku'] = $product->get_sku();
             /* below statement make sure every add to cart action as unique line item */
@@ -96,30 +133,40 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
             $custom_items = $cart_data;
         }
 
-        [$smartstone_category, $smartstone_id] = self::getItemId($cart_item["acore_item_sku"]);
-        if (!$smartstone_id) {
+        if (empty($cart_item["acore_item_sku"])) {
             return $custom_items;
         }
+        $parsed = self::getItemId($cart_item["acore_item_sku"]);
+        if (!$parsed) {
+            return $custom_items;
+        }
+        [$smartstone_category, $smartstone_id] = $parsed;
 
-        if (isset($cart_item['acore_char_sel'])) {
+        // Indexes match mod-chromiecraft-smartstone's ActionType enum (src/Smartstone.h):
+        //   0 = Companion, 1 = Pet, 2 = Costume, 7 = Vehicle, 8 = Mount, 9 = Perk
+        $categoryToText = array(
+            0 => "Pet",
+            1 => "Combat Pet",
+            2 => "Costume",
+            9 => "Class Perk",
+        );
+        $label = isset($categoryToText[$smartstone_category])
+            ? $categoryToText[$smartstone_category]
+            : "Smartstone item";
+
+        if (self::isAccountWide($smartstone_category)) {
+            $custom_items[] = array("name" => 'Unlock for', "value" => 'Entire account');
+            $custom_items[] = array("name" => $label, "value" => $smartstone_id);
+        } else if (isset($cart_item['acore_char_sel'])) {
             $ACoreSrv = ACoreServices::I();
             $charRepo = $ACoreSrv->getCharactersRepo();
 
             $charId = $cart_item['acore_char_sel'];
-
             $char = $charRepo->findOneByGuid($charId);
-
             $charName = $char ? $char->getName() : "Character <$charId> doesn't exist!";
 
-            // Add to this dictionary / array to show other catergories for vanity items.
-            $categoryToText = array(
-                0 => "Pet",
-                1 => "Combat Pet",
-                2 => "Costume",
-            );
-
             $custom_items[] = array("name" => 'Character', "value" => $charName);
-            $custom_items[] = array("name" => $categoryToText[$smartstone_category], "value" => $smartstone_id);
+            $custom_items[] = array("name" => $label, "value" => $smartstone_id);
         }
         return $custom_items;
     }
@@ -127,14 +174,21 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
     // ADD DATA TO FINAL ORDER META
     // This is a piece of code that will add your custom field with order meta.
     public static function add_order_item_meta($item_id, $values, $cart_item_key) {
-        [$smartstone_category, $smartstone_id] = self::getItemId($values['acore_item_sku']);
-        if (!$smartstone_id) {
+        if (empty($values['acore_item_sku'])) {
             return;
         }
+        $parsed = self::getItemId($values['acore_item_sku']);
+        if (!$parsed) {
+            return;
+        }
+        [$smartstone_category, $smartstone_id] = $parsed;
 
-        if (isset($values['acore_char_sel']) && isset($values["acore_item_sku"])) {
+        \wc_add_order_item_meta($item_id, "acore_item_sku", $values['acore_item_sku']);
+
+        // Character is only relevant for per-character unlocks. For account-wide
+        // categories, the buyer's account is derived from the order customer in payment_complete.
+        if (!self::isAccountWide($smartstone_category) && isset($values['acore_char_sel'])) {
             \wc_add_order_item_meta($item_id, "acore_char_sel", $values['acore_char_sel']);
-            \wc_add_order_item_meta($item_id, "acore_item_sku", $values['acore_item_sku']);
         }
     }
 
@@ -166,19 +220,41 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
 
             $soap = $WoWSrv->getSmartstoneSoap();
 
+            // Resolve buyer's AC account name once (needed for account-wide unlocks).
+            $accountName = null;
+            $customerId = $order->get_customer_id();
+            if ($customerId) {
+                $buyer = \get_user_by('id', $customerId);
+                if ($buyer) {
+                    $accountName = $buyer->user_login;
+                }
+            }
+
             foreach ($items as $item) {
-                if (isset($item["acore_item_sku"])) {
-                    [$smartstone_category, $smartstone_id] = self::getItemId($item["acore_item_sku"]);
+                if (!isset($item["acore_item_sku"])) {
+                    continue;
+                }
+                $parsed = self::getItemId($item["acore_item_sku"]);
+                if (!$parsed) {
+                    continue;
+                }
+                [$smartstone_category, $smartstone_id] = $parsed;
 
-                    if ($smartstone_id) {
-                        $charName = $WoWSrv->getCharName($item["acore_char_sel"]);
-
-                        $res = $soap->addVanity($charName, $smartstone_category, $smartstone_id);
-
-                        if ($res instanceof \Exception) {
-                            throw $res;
-                        }
+                if (self::isAccountWide($smartstone_category)) {
+                    if (!$accountName) {
+                        throw new \Exception("Smartstone account-wide unlock requires a buyer with a linked AC account; order $order_id has none.");
                     }
+                    $res = $soap->addAccountVanity($accountName, $smartstone_category, $smartstone_id);
+                } else {
+                    if (empty($item["acore_char_sel"])) {
+                        throw new \Exception("Smartstone per-character unlock missing acore_char_sel on item in order $order_id.");
+                    }
+                    $charName = $WoWSrv->getCharName($item["acore_char_sel"]);
+                    $res = $soap->addVanity($charName, $smartstone_category, $smartstone_id);
+                }
+
+                if ($res instanceof \Exception) {
+                    throw $res;
                 }
             }
         } catch (\Exception $e) {

--- a/src/acore-wp-plugin/src/Manager/Soap/SmartstoneService.php
+++ b/src/acore-wp-plugin/src/Manager/Soap/SmartstoneService.php
@@ -12,4 +12,13 @@ class SmartstoneService {
         return $this->executeCommand(".smartstone unlock service $charName $category $vanityID true");
     }
 
+    /**
+     * Unlock a service for the entire account (account-wide).
+     * Only ACTION_TYPE_COSTUME (2) and ACTION_TYPE_PERK (9) are accepted server-side;
+     * other service types will be rejected by the mod's HandleSmartStoneUnlockAccountCommand.
+     */
+    public function addAccountVanity($accountName, $category, $vanityID) {
+        return $this->executeCommand(".smartstone unlock account $accountName $category $vanityID true");
+    }
+
 }

--- a/src/acore-wp-plugin/src/Manager/Soap/SmartstoneService.php
+++ b/src/acore-wp-plugin/src/Manager/Soap/SmartstoneService.php
@@ -16,8 +16,14 @@ class SmartstoneService {
      * Unlock a service for the entire account (account-wide).
      * Only ACTION_TYPE_COSTUME (2) and ACTION_TYPE_PERK (9) are accepted server-side;
      * other service types will be rejected by the mod's HandleSmartStoneUnlockAccountCommand.
+     *
+     * $accountName is expected to come from a WordPress user_login (sanitize_user
+     * restricts these to alphanumerics, dot, hyphen, underscore, at — no spaces),
+     * but we still cast the numeric args at the boundary as belt-and-braces.
      */
     public function addAccountVanity($accountName, $category, $vanityID) {
+        $category = (int) $category;
+        $vanityID = (int) $vanityID;
         return $this->executeCommand(".smartstone unlock account $accountName $category $vanityID true");
     }
 


### PR DESCRIPTION
## Summary

`mod-chromiecraft-smartstone` recently added a `.smartstone unlock account <accountNameOrId> <serviceType> <id> <add>` command that unlocks a service for an entire AC account rather than a single character. Server-side, the handler (`HandleSmartStoneUnlockAccountCommand` in `src/cs_smartstone.cpp`) only accepts `ACTION_TYPE_COSTUME` (2) and `ACTION_TYPE_PERK` (9); other service types fall through with `LANG_MOD_UNKNOWN_SERVICE_TYPE`.

This PR teaches the WooCommerce-side flow to use it. For SKUs in those categories the WP plugin no longer requires the buyer to select a character at any step — costumes and perks are inherently account-scoped on the server, so demanding a character pick was always vestigial.

### Changes

- **`SmartstoneService.php`** — add `addAccountVanity($accountName, $category, $vanityID)` wrapping the new SOAP command. Existing `addVanity()` (per-character `.smartstone unlock service`) is untouched.
- **`Smartstone.php`** — introduce a single source of truth `ACCOUNT_WIDE_CATEGORIES = [2, 9]` and an `isAccountWide()` helper, then branch each WooCommerce lifecycle hook on it:
  - `before_add_to_cart_button`: render the 3D viewer only, skip `FieldElements::charList()`
  - `add_to_cart_validation`: require login but skip the `acore_char_sel` check
  - `add_cart_item_data`: stash `acore_item_sku` + `unique_key` without `acore_char_sel`
  - `get_item_data`: render "Unlock for: Entire account" instead of a character row
  - `add_order_item_meta`: write `acore_item_sku` only
  - `payment_complete`: resolve the buyer's `user_login` from the order's customer and call `addAccountVanity()`; per-character categories still call `addVanity()`

### Drive-by hardening

`getItemId()` previously returned `false` for non-smartstone SKUs but every call site did `[$cat, $id] = self::getItemId(...)`, which destructures `false` into `[null, null]` with a PHP notice. Replaced that pattern at all call sites with an explicit `$parsed = ...; if (!$parsed) return; [$cat, $id] = $parsed;`. Also guarded non-string / short SKUs in `getItemId()` itself and cast `category`/`id` to `int` once at the source so downstream strict comparisons work as expected.

### Backwards compatibility

Per-character categories (Companion=0, Pet=1, any other value) keep their existing behavior. The `addVanity()` SOAP method is unchanged. New behavior is gated entirely on `in_array($category, [2, 9], true)`.

### When the mod expands the account-wide command

If `HandleSmartStoneUnlockAccountCommand` ever accepts more service types (mounts, vehicles, …), update the single `ACCOUNT_WIDE_CATEGORIES` constant.

## Test plan

- [ ] Per-character SKU (e.g. `smartstone_0_<companionId>`) on product page still shows the character selector; Add to cart with no character → "No character selected"; with a character → checkout shows "Character: X"; `payment_complete` fires `.smartstone unlock service <char> 0 <id> true`.
- [ ] Account-wide costume SKU (`smartstone_2_<costumeId>`) on product page shows **no** character selector; Add to cart works without picking a character; cart/checkout shows "Unlock for: Entire account"; `payment_complete` fires `.smartstone unlock account <buyerLogin> 2 <id> true`.
- [ ] Account-wide perk SKU (`smartstone_9_<perkId>`) behaves identically to costumes.
- [ ] Logged-out user on any smartstone SKU still gets "You must be logged in to buy it!"
- [ ] Buyer with no matching AC account (no row in `acore_auth.account` for their `user_login`) gets an exception logged to `acore_log` in `payment_complete` for account-wide SKUs (current behavior preserved — surfacing this earlier in validation is left as a follow-up).
- [ ] Mixed cart (one per-character + one account-wide) checks out cleanly and fires both SOAP commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)