### PR TITLE
fix: prevent fatal on long user passwords

### DIFF
--- a/src/acore-wp-plugin/src/Manager/UserValidator.php
+++ b/src/acore-wp-plugin/src/Manager/UserValidator.php
@@ -21,8 +21,8 @@ class UserValidator {
     {
         if (strlen($password) > UserValidator::PASSWORD_LENGTH) {
             return sprintf(
-                __("Password is too long (%s), please use less then %s characters", 'acore_wp_plugin'),
-                strlen($password), PASSWORD_LENGTH
+                __("Password is too long (%s), please use %s characters or fewer", 'acore_wp_plugin'),
+                strlen($password), UserValidator::PASSWORD_LENGTH
             );
         }
 


### PR DESCRIPTION
## Summary
- Fix a fatal error in user password validation when a password exceeds the ACore max length.
- Qualify the password length constant as `UserValidator::PASSWORD_LENGTH` and make the validation message explicit.

## Why
WordPress-generated passwords can exceed the 16-character ACore account limit. The validator attempted to return a readable error, but referenced an undefined global `PASSWORD_LENGTH` constant, causing a PHP fatal error instead.

## Testing
- `git show --check HEAD`
- Not run: `php -l` / runtime PHP validation because PHP is not installed on this worker.
