### PR TITLE
fix: prevent password length validation fatal

### DIFF
--- a/src/acore-wp-plugin/src/Manager/UserValidator.php
+++ b/src/acore-wp-plugin/src/Manager/UserValidator.php
@@ -21,8 +21,8 @@ class UserValidator {
     {
         if (strlen($password) > UserValidator::PASSWORD_LENGTH) {
             return sprintf(
-                __("Password is too long (%s), please use less then %s characters", 'acore_wp_plugin'),
-                strlen($password), PASSWORD_LENGTH
+                __("Password is too long (%s), please use %s characters or fewer", 'acore_wp_plugin'),
+                strlen($password), UserValidator::PASSWORD_LENGTH
             );
         }
 


### PR DESCRIPTION
## Changes
- Qualifies the password length constant as \ACore\Manager\UserValidator::PASSWORD_LENGTH during WordPress password validation.
- Updates the validation message wording while keeping the same 16-character limit.

## Why
When a submitted password is longer than the AzerothCore limit, the validator tried to read an unqualified PASSWORD_LENGTH constant. In PHP 8 this can fatal instead of returning a validation error to WordPress.

## Testing
- Passed: git diff --check
- Not run: php -l, composer tests; php/composer/docker are not installed in this runtime.