### PR TITLE
feat(smartstone): allow gifting account-wide unlocks and cap quantity at 1

### DIFF
--- a/src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php
+++ b/src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php
@@ -41,6 +41,37 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
         add_action('woocommerce_add_order_item_meta', self::sprefix() . 'add_order_item_meta', 1, 3);
         add_action('woocommerce_payment_complete', self::sprefix() . 'payment_complete');
         add_action('woocommerce_add_to_cart_validation', [__CLASS__, 'add_to_cart_validation'], 10, 5);
+        // Smartstone SKUs are one-shot unlocks (per-character for cat 0/1, per-account
+        // for cat 2/9), so the quantity selector is meaningless. Cap it at 1 on both
+        // the product page and the cart row. Multiple gift lines for the same SKU are
+        // still possible via unique_key in add_cart_item_data.
+        add_filter('woocommerce_quantity_input_args', [__CLASS__, 'quantity_input_args'], 10, 2);
+        add_filter('woocommerce_cart_item_quantity', [__CLASS__, 'cart_item_quantity'], 10, 3);
+    }
+
+    /**
+     * Lock the product-page quantity input at 1 for smartstone SKUs.
+     * When min == max, WC renders the input as plain text (no +/- buttons).
+     */
+    public static function quantity_input_args($args, $product) {
+        if ($product && strpos((string) $product->get_sku(), 'smartstone') === 0) {
+            $args['min_value']   = 1;
+            $args['max_value']   = 1;
+            $args['input_value'] = 1;
+        }
+        return $args;
+    }
+
+    /**
+     * Lock the cart-row quantity at 1 for smartstone line items. Returning a
+     * plain string here replaces WC's quantity input with non-editable text.
+     */
+    public static function cart_item_quantity($product_quantity, $cart_item_key, $cart_item) {
+        if (!empty($cart_item['acore_item_sku'])
+            && strpos((string) $cart_item['acore_item_sku'], 'smartstone') === 0) {
+            return '1';
+        }
+        return $product_quantity;
     }
 
      // Validator for add to cart from external sources (no character selected) or logged in required from "CartValidation")
@@ -66,8 +97,32 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
         [$smartstone_category, $smartstone_id] = $parsed;
 
         // Account-wide services (costumes, perks) unlock via `.smartstone unlock account`
-        // and do not need a character selection.
+        // and do not need a character selection. They optionally accept a recipient
+        // character name (gifting) — validate it here if provided.
         if (self::isAccountWide($smartstone_category)) {
+            $destName = isset($_REQUEST['acore_char_dest']) ? trim((string) $_REQUEST['acore_char_dest']) : '';
+            if ($destName !== '') {
+                $ACoreSrv      = ACoreServices::I();
+                $charRepo      = $ACoreSrv->getCharactersRepo();
+                $charBanRepo   = $ACoreSrv->getCharactersBannedRepo();
+                $accBanRepo    = $ACoreSrv->getAccountBannedRepo();
+
+                $char = $charRepo->findOneByName($destName);
+                if (!$char) {
+                    \wc_add_notice(__('Recipient character not found.', 'acore-wp-plugin'), 'error');
+                    return false;
+                }
+                if ($charBanRepo->isActiveByGuid($char->getGuid())) {
+                    \wc_add_notice(__('Recipient character is banned.', 'acore-wp-plugin'), 'error');
+                    return false;
+                }
+                if ($accBanRepo->isActiveById($char->getAccount())) {
+                    \wc_add_notice(__('Recipient account is banned.', 'acore-wp-plugin'), 'error');
+                    return false;
+                }
+                // Self-gift (recipient char belongs to the buyer's own account) is
+                // silently treated as a regular self-unlock; nothing to error on here.
+            }
             return $passed;
         }
 
@@ -91,8 +146,10 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
 
         FieldElements::get3dViewer();
 
-        // Account-wide unlocks (costumes, perks) don't need a character selector.
+        // Account-wide unlocks (costumes, perks) don't need a self character
+        // selector, but they support gifting to a character on another account.
         if (self::isAccountWide($smartstone_category)) {
+            FieldElements::destCharacter(__('Gift to a character (optional — leave blank to unlock for your own account):', 'acore-wp-plugin'));
             return;
         }
 
@@ -119,6 +176,26 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
             // and force a unique line so the cart treats it as its own row.
             $cart_item_data['acore_item_sku'] = $product->get_sku();
             $cart_item_data['unique_key'] = md5(microtime() . rand());
+
+            // If a recipient character was supplied, resolve it to an account
+            // name now so payment_complete can route the SOAP call there.
+            // add_to_cart_validation has already vetted existence/ban state.
+            $destName = isset($_REQUEST['acore_char_dest']) ? trim((string) $_REQUEST['acore_char_dest']) : '';
+            if ($destName !== '') {
+                $ACoreSrv = ACoreServices::I();
+                $char = $ACoreSrv->getCharactersRepo()->findOneByName($destName);
+                if ($char) {
+                    $account = $ACoreSrv->getAccountRepo()->findOneById($char->getAccount());
+                    $current_user = wp_get_current_user();
+                    if ($account && $current_user
+                        && strcasecmp($account->getUsername(), $current_user->user_login) !== 0) {
+                        // Real gift: recipient belongs to a different account.
+                        $cart_item_data['acore_gift_account']  = $account->getUsername();
+                        $cart_item_data['acore_gift_charname'] = $char->getName();
+                    }
+                    // Self-gift falls through with no gift_* fields => self-unlock.
+                }
+            }
         } else if (isset($_REQUEST['acore_char_sel'])) {
             $cart_item_data['acore_char_sel'] = $_REQUEST['acore_char_sel'];
             $cart_item_data['acore_item_sku'] = $product->get_sku();
@@ -158,7 +235,14 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
             : "Smartstone item";
 
         if (self::isAccountWide($smartstone_category)) {
-            $custom_items[] = array("name" => 'Unlock for', "value" => 'Entire account');
+            if (isset($cart_item['acore_gift_account'])) {
+                $giftCharname = isset($cart_item['acore_gift_charname'])
+                    ? $cart_item['acore_gift_charname']
+                    : '(recipient)';
+                $custom_items[] = array("name" => 'Gift for', "value" => $giftCharname);
+            } else {
+                $custom_items[] = array("name" => 'Unlock for', "value" => 'Entire account');
+            }
             $custom_items[] = array("name" => $label, "value" => $smartstone_id);
         } else if (isset($cart_item['acore_char_sel'])) {
             $ACoreSrv = ACoreServices::I();
@@ -192,6 +276,16 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
         // categories, the buyer's account is derived from the order customer in payment_complete.
         if (!self::isAccountWide($smartstone_category) && isset($values['acore_char_sel'])) {
             \wc_add_order_item_meta($item_id, "acore_char_sel", $values['acore_char_sel']);
+        }
+
+        // Gifting: persist the resolved recipient so payment_complete can route
+        // the SOAP unlock to their account. Charname is informational (for admin
+        // order view); only acore_gift_account is functional.
+        if (self::isAccountWide($smartstone_category) && isset($values['acore_gift_account'])) {
+            \wc_add_order_item_meta($item_id, "acore_gift_account", $values['acore_gift_account']);
+            if (isset($values['acore_gift_charname'])) {
+                \wc_add_order_item_meta($item_id, "acore_gift_charname", $values['acore_gift_charname']);
+            }
         }
     }
 
@@ -244,10 +338,15 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
                 [$smartstone_category, $smartstone_id] = $parsed;
 
                 if (self::isAccountWide($smartstone_category)) {
-                    if (!$accountName) {
+                    // Gifted items route to the recipient's account; otherwise unlock
+                    // for the buyer. Resolution + ban-check happened at add-to-cart time.
+                    $target = !empty($item['acore_gift_account'])
+                        ? $item['acore_gift_account']
+                        : $accountName;
+                    if (!$target) {
                         throw new \Exception("Smartstone account-wide unlock requires a buyer with a linked AC account; order $order_id has none.");
                     }
-                    $res = $soap->addAccountVanity($accountName, $smartstone_category, $smartstone_id);
+                    $res = $soap->addAccountVanity($target, $smartstone_category, $smartstone_id);
                 } else {
                     if (empty($item["acore_char_sel"])) {
                         throw new \Exception("Smartstone per-character unlock missing acore_char_sel on item in order $order_id.");


### PR DESCRIPTION
## Summary

Builds on #190 (account-wide smartstone unlocks) with two related UX changes on the same WooCommerce flow.

### 1. Gifting (Costumes, Perks)

Lets buyers gift any account-wide smartstone product to another player by entering a **character name** on the product page. The plugin resolves it to that character's owning AC account and routes the SOAP unlock there at payment time.

UX mirrors the existing item-gifting flow in `ItemSend.php` — buyers never type an account name (AC account logins are semi-private and unfriendly UX); they type a character name they don't need to own.

- **Every account-wide product page** renders a `FieldElements::destCharacter` input below the 3D viewer with the label *"Gift to a character (optional — leave blank to unlock for your own account)"*. No per-product opt-in toggle.
- **Empty input** → buyer's own account unlocks (existing #190 behavior, unchanged).
- **Recipient name supplied:**
  - At `add_to_cart_validation`: looked up via `findOneByName`. Rejected with a notice if the character doesn't exist, the character is banned, or the recipient's account is banned.
  - At `add_cart_item_data`: resolved to the recipient's account name and stashed in cart_item_data as `acore_gift_account` (functional) + `acore_gift_charname` (display).
  - At `get_item_data`: cart line shows *"Gift for: \<character name\>"* instead of *"Unlock for: Entire account"*.
  - At `add_order_item_meta`: both gift fields persisted on the order item.
  - At `payment_complete`: `addAccountVanity()` is called with the gift account instead of the buyer's.
- **Self-gift** (recipient character belongs to the buyer's own AC account, case-insensitive compare): silently treated as a regular self-unlock. No error notice — the gift fields are simply not stashed, and the cart line falls back to the standard *"Unlock for: Entire account"* display.
- **Per-character categories** (Companion=0, Pet=1, others) are completely untouched.

### 2. Quantity cap

Every smartstone SKU is a one-shot unlock — per-character for ACTION_TYPE_COMPANION (0) / ACTION_TYPE_PET (1), per-account for ACTION_TYPE_COSTUME (2) / ACTION_TYPE_PERK (9). A quantity > 1 is nonsensical: a second unlock for the same SKU on the same target is either rejected by the mod (`LANG_MOD_SERVICE_ALREADY_UNLOCKED`) or a silent no-op. The buyer just pays N times for the same thing.

- `woocommerce_quantity_input_args` filter: forces `min = max = input_value = 1` on the product-page selector for any SKU starting with `smartstone`. WC's `wc_quantity_input()` renders the field as plain text "1" (no +/- buttons) when min == max.
- `woocommerce_cart_item_quantity` filter: returns a plain `"1"` string for the cart-row quantity, making it non-editable after add-to-cart.

Multiple cart lines for the same SKU are still supported (e.g. gifting the same costume to two different recipients) — the existing `unique_key` in `add_cart_item_data` forces each add into its own line. Using the `sold_individually` flag would block this, so it's intentionally not used.

## Scope

- Only `src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php` is touched (+104, −5).
- All repository methods used here (`findOneByName`, `findOneById`, `getCharactersBannedRepo`, `getAccountBannedRepo`) are already used in `CartValidation.php` and `FieldElements.php`.
- No new SOAP wrapper, no new SKU shape, no changes to the per-character flow.

## Known limitation (deferred)

The original spec asked for an **at-add-to-cart "already unlocked" check** for gifting, but the mod stores account-wide unlocks in `acore_auth.smartstone_account_settings.data` as a serialized `PlayerSettingVector` binary blob — and perks share a `settingId` slot per class (all Druid perks → `settingId=110`), so a row-existence check would incorrectly block buying a second Druid perk if the recipient owns any. A proper duplicate check requires parsing the AC binary settings format from PHP, which is out of scope here.

Current behavior on a duplicate gift: the SOAP server returns `LANG_MOD_SERVICE_ALREADY_UNLOCKED`, `payment_complete` catches it and writes it to the `acore_log` WooCommerce logger, and the buyer's WooCommerce order still completes. Worth a follow-up issue.

## Test plan

### Gifting
- [ ] Account-wide product page (e.g. `smartstone_2_<costumeId>`) renders the *"Gift to a character"* input field below the 3D viewer.
- [ ] Empty input → checkout completes as before, buyer's account gets the unlock, cart shows *"Unlock for: Entire account"*.
- [ ] Recipient name of a character on **another** account: cart line shows *"Gift for: \<charname\>"*; `payment_complete` fires `.smartstone unlock account <recipient-account-login> <cat> <id> true`.
- [ ] Recipient name of a character on the **buyer's own** account: silently behaves like empty input (no notice, no gift fields, self-unlock path).
- [ ] Non-existent character name → *"Recipient character not found."* notice; Add to cart fails.
- [ ] Banned character → *"Recipient character is banned."* notice; Add to cart fails.
- [ ] Character on a banned account → *"Recipient account is banned."* notice; Add to cart fails.
- [ ] Per-character products (`smartstone_0_*`, `smartstone_1_*`) are unaffected — character selector still appears, validation still requires `acore_char_sel`.
- [ ] Mixed cart (one gifted costume + one self-unlock perk + one per-character pet) checks out cleanly and fires three distinct SOAP commands with the right targets.

### Quantity cap
- [ ] Any smartstone product page renders quantity as plain text "1" (no +/- buttons).
- [ ] Same product added to cart twice with different gift recipients produces two cart lines, each locked at qty 1.
- [ ] Cart row qty for any smartstone line is non-editable text.
- [ ] Non-smartstone products' quantity selector is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “Gift to a character” destination field for account-wide smartstone unlocks during checkout.
  * Checkout and order item details now display “Gift for” with the recipient name when gifting; otherwise show “Unlock for: Entire account.”

* **Bug Fixes / Improvements**
  * Smartstone quantity is capped to `1`, and cart-row quantities for smartstone items are no longer editable.
  * Self-gifting is allowed, while ban checks are enforced for the recipient when gifting.
  * Account-wide unlock routing now targets the recipient’s linked account when a destination character is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->