### PR TITLE
Fix Redis PECL installation during Docker builds

### DIFF
--- a/data/docker/Wordpress.Dockerfile
+++ b/data/docker/Wordpress.Dockerfile
@@ -40,8 +40,13 @@ RUN docker-php-ext-install soap \
     && docker-php-ext-install gmp
 
 # Install Redis PHP extension
-RUN pecl install redis \
-    && docker-php-ext-enable redis
+ARG REDIS_PECL_VERSION=6.3.0
+
+RUN curl -fsSL -o /tmp/redis.tgz \
+    "https://pecl.php.net/get/redis-${REDIS_PECL_VERSION}.tgz" \
+    && pecl install /tmp/redis.tgz \
+    && docker-php-ext-enable redis \
+    && rm -f /tmp/redis.tgz
 
 # Install Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer


### PR DESCRIPTION
## Summary

Fix Redis PHP extension installation during Docker builds.

## Problem

The following command fails during the image build:

```dockerfile
RUN pecl install redis \
    && docker-php-ext-enable redis
```

with the error:

```text
No releases available for package "pecl.php.net/redis"
```

Attempting to refresh the PECL channel also fails:

```text
XML Error: 'Not well-formed (invalid token)' on line '1'
```

## Solution

Download the Redis extension tarball directly from PECL and install it locally.

The Redis version is exposed as a build argument to keep the build reproducible while making future updates straightforward.

```dockerfile
ARG REDIS_PECL_VERSION=6.3.0

RUN curl -fsSL -o /tmp/redis.tgz \
    "https://pecl.php.net/get/redis-${REDIS_PECL_VERSION}.tgz" \
    && pecl install /tmp/redis.tgz \
    && docker-php-ext-enable redis \
    && rm -f /tmp/redis.tgz
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to improve stability of the Redis extension installation process by pinning the extension version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->