### PR TITLE
[7 / 7] - Admin settings + Cross-site request forgery / Nonces

### DIFF
--- a/src/acore-wp-plugin/src/Components/AdminPanel/Pages/ElunaSettings.php
+++ b/src/acore-wp-plugin/src/Components/AdminPanel/Pages/ElunaSettings.php
@@ -6,6 +6,7 @@
     <h2> <?= __('AzerothCore Settings', Opts::I()->page_alias) ?></h2>
     <p>Configure database connection for Eluna script that need use of the CMS.</p>
     <form name="form-acore-eluna-settings" method="post" action="">
+        <?php wp_nonce_field('acore_eluna_settings_save', 'acore_eluna_settings_nonce'); ?>
         <div class="row">
             <div class="col-sm-6">
                 <div class="card p-0">

--- a/src/acore-wp-plugin/src/Components/AdminPanel/Pages/PVPRewards.php
+++ b/src/acore-wp-plugin/src/Components/AdminPanel/Pages/PVPRewards.php
@@ -14,6 +14,7 @@
                     <h5>Give rewards</h5>
                     <hr>
                     <form name="pvp-rewards" method="post" id="pvp-rewards" class="initial-form hide-if-no-js">
+                        <?php wp_nonce_field('acore_pvp_rewards_save', 'acore_pvp_rewards_nonce'); ?>
                         <input type="hidden" name="page" value="<?= ACORE_SLUG . '-pvp-rewards'; ?>" />
                         <table class="form-table table table-borderless" role="presentation">
                             <tbody>

--- a/src/acore-wp-plugin/src/Components/AdminPanel/Pages/RealmSettings.php
+++ b/src/acore-wp-plugin/src/Components/AdminPanel/Pages/RealmSettings.php
@@ -1,254 +1,392 @@
 <?php
     use ACore\Manager\Opts;
+
+    $modulesCsv        = get_option('acore_modules_csv', '');
+    $modulesRefreshed  = intval(get_option('acore_modules_refreshed', 0));
+    $storedModules     = $modulesCsv ? array_values(array_filter(explode(',', $modulesCsv))) : [];
+    $storedRequirements = get_option('acore_module_requirements', [['Scroll of Resurrection', 'mod-resurrection-scroll']]);
+    $referencedSlugs    = array_values(array_unique(array_filter(array_map(function ($r) {
+        return isset($r[1]) ? trim($r[1]) : '';
+    }, $storedRequirements))));
 ?>
 
 <div class="wrap">
     <h2><?= __('AzerothCore Settings', Opts::I()->page_alias) ?></h2>
     <p>Configure realm name and database connection.</p>
-    <form name="form-acore-settings" method="post" action="">
-        <div class="card w-50 p-0">
-            <div class="card-body">
-                <h5>
-                    General Settings
-                </h5>
-                <hr>
-                <table class="form-table table table-borderless" role="presentation">
-                    <tbody>
-                        <tr>
-                            <th scope="row">
-                                <label for="acore_realm_alias">Realm Name:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_realm_alias" value="<?= Opts::I()->acore_realm_alias; ?>" size="20" placeholder="AzerothCore">
-                            </td>
-                        </tr>
-                    </tbody>
-                    
-                </table>
-                <p>
-                    <a href="https://www.azerothcore.org/wiki/remote-access">First time using SOAP? Click me!</a>
+
+    <div style="display:flex; gap:20px; align-items:flex-start;">
+
+        <!-- Col 1: settings form (35%) -->
+        <div style="flex:0 0 auto; width:35%;">
+            <form name="form-acore-settings" method="post" action="">
+                <?php wp_nonce_field('acore_realm_settings_save', 'acore_realm_settings_nonce'); ?>
+                <div class="card p-0">
+                    <div class="card-body">
+                        <h5>General Settings</h5>
+                        <hr>
+                        <table class="form-table table table-borderless" role="presentation">
+                            <tbody>
+                                <tr>
+                                    <th scope="row"><label for="acore_realm_alias">Realm Name:</label></th>
+                                    <td><input type="text" name="acore_realm_alias" value="<?= esc_attr(Opts::I()->acore_realm_alias); ?>" size="20" placeholder="AzerothCore"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <p><a href="https://www.azerothcore.org/wiki/remote-access">First time using SOAP? Click me!</a></p>
+                        <hr />
+                        <h5 style="display:flex; align-items:stretch; justify-content:space-between; margin:0; line-height:1;">
+                            <span style="line-height:1;">SOAP Settings</span>
+                            <?php if (Opts::I()->acore_soap_host && Opts::I()->acore_soap_user): ?>
+                            <span id="acore-soap-status" style="display:inline-flex; align-items:center; justify-content:center; align-self:stretch; font-size:9px; font-weight:700; color:#fff; background:#8b949e; padding:0 7px; border-radius:3px; min-width:52px; line-height:1; text-transform:uppercase; letter-spacing:0.06em;">Checking…</span>
+                            <?php endif; ?>
+                        </h5>
+                        <table class="form-table table table-borderless" role="presentation">
+                            <tbody>
+                                <tr>
+                                    <th scope="row"><label for="acore_soap_host">IPv4:</label></th>
+                                    <td><input type="text" name="acore_soap_host" value="<?= esc_attr(Opts::I()->acore_soap_host); ?>" size="20" placeholder="127.0.0.1"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_soap_port">Port:</label></th>
+                                    <td><input type="text" name="acore_soap_port" value="<?= esc_attr(Opts::I()->acore_soap_port); ?>" size="20" placeholder="7878"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_soap_user">Username:</label></th>
+                                    <td><input type="text" name="acore_soap_user" value="<?= esc_attr(Opts::I()->acore_soap_user); ?>" size="20"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_soap_pass">Password:</label></th>
+                                    <td><input type="password" name="acore_soap_pass" value="<?= esc_attr(Opts::I()->acore_soap_pass); ?>" size="20"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <hr />
+                        <h5>Database: Auth</h5>
+                        <table class="form-table table table-borderless" role="presentation">
+                            <tbody>
+                                <tr>
+                                    <th scope="row"><label for="acore_db_auth_host">IPv4:</label></th>
+                                    <td><input type="text" name="acore_db_auth_host" value="<?= esc_attr(Opts::I()->acore_db_auth_host); ?>" size="20" placeholder="127.0.0.1"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_db_auth_port">Port:</label></th>
+                                    <td><input type="text" name="acore_db_auth_port" value="<?= esc_attr(Opts::I()->acore_db_auth_port); ?>" size="20" placeholder="3306"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_db_auth_user">Username:</label></th>
+                                    <td><input type="text" name="acore_db_auth_user" value="<?= esc_attr(Opts::I()->acore_db_auth_user); ?>" size="20" placeholder="acore"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_db_auth_pass">Password:</label></th>
+                                    <td><input type="password" name="acore_db_auth_pass" value="<?= esc_attr(Opts::I()->acore_db_auth_pass); ?>" size="20" placeholder="acore"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_db_auth_name">Database Name:</label></th>
+                                    <td><input type="text" name="acore_db_auth_name" value="<?= esc_attr(Opts::I()->acore_db_auth_name); ?>" size="20" placeholder="acore_auth"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <hr />
+                        <h5>Database: Characters</h5>
+                        <table class="form-table table table-borderless" role="presentation">
+                            <tbody>
+                                <tr>
+                                    <th scope="row"><label for="acore_db_char_host">IPv4:</label></th>
+                                    <td><input type="text" name="acore_db_char_host" value="<?= esc_attr(Opts::I()->acore_db_char_host); ?>" size="20" placeholder="127.0.0.1"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_db_char_port">Port:</label></th>
+                                    <td><input type="text" name="acore_db_char_port" value="<?= esc_attr(Opts::I()->acore_db_char_port); ?>" size="20" placeholder="3306"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_db_char_user">Username:</label></th>
+                                    <td><input type="text" name="acore_db_char_user" value="<?= esc_attr(Opts::I()->acore_db_char_user); ?>" size="20" placeholder="acore"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_db_char_pass">Password:</label></th>
+                                    <td><input type="password" name="acore_db_char_pass" value="<?= esc_attr(Opts::I()->acore_db_char_pass); ?>" size="20" placeholder="acore"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_db_char_name">Database Name:</label></th>
+                                    <td><input type="text" name="acore_db_char_name" value="<?= esc_attr(Opts::I()->acore_db_char_name); ?>" size="20" placeholder="acore_characters"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <hr />
+                        <h5>Database: World</h5>
+                        <table class="form-table table table-borderless" role="presentation">
+                            <tbody>
+                                <tr>
+                                    <th scope="row"><label for="acore_db_world_host">IPv4:</label></th>
+                                    <td><input type="text" name="acore_db_world_host" value="<?= esc_attr(Opts::I()->acore_db_world_host); ?>" size="20" placeholder="127.0.0.1"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_db_world_port">Port:</label></th>
+                                    <td><input type="text" name="acore_db_world_port" value="<?= esc_attr(Opts::I()->acore_db_world_port); ?>" size="20" placeholder="3306"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_db_world_user">Username:</label></th>
+                                    <td><input type="text" name="acore_db_world_user" value="<?= esc_attr(Opts::I()->acore_db_world_user); ?>" size="20" placeholder="acore"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_db_world_pass">Password:</label></th>
+                                    <td><input type="password" name="acore_db_world_pass" value="<?= esc_attr(Opts::I()->acore_db_world_pass); ?>" size="20" placeholder="acore"></td>
+                                </tr>
+                                <tr>
+                                    <th><label for="acore_db_world_name">Database Name:</label></th>
+                                    <td><input type="text" name="acore_db_world_name" value="<?= esc_attr(Opts::I()->acore_db_world_name); ?>" size="20" placeholder="acore_world"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <div id="ajax-message"></div>
+
+                <p class="submit">
+                    <input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e('Save Changes', Opts::I()->page_alias) ?>" />
+                    <input type="button" name="check-soap" id="check-soap" class="button-secondary" value="<?php esc_attr_e('Check SOAP', Opts::I()->page_alias) ?>" />
                 </p>
-                <hr />
-                <table class="form-table table table-borderless" role="presentation">
-                <h5>
-                    SOAP Settings
-                </h5>
-                    <tbody>
-                        <tr>
-                            <th scope="row">
-                                <label for="acore_soap_host">IPv4:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_soap_host" value="<?= Opts::I()->acore_soap_host; ?>" size="20" placeholder="127.0.0.1">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_soap_port">Port:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_soap_port" value="<?= Opts::I()->acore_soap_port; ?>" size="20" placeholder="7878">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_soap_user">Username:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_soap_user" value="<?= Opts::I()->acore_soap_user; ?>" size="20" >
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_realm_alias">Password:</label>
-                            </th>
-                            <td>
-                                <input type="password" name="acore_soap_pass" value="<?= Opts::I()->acore_soap_pass; ?>" size="20" >
-                            </td>
-                        </tr>
-                        <tr>
-                    </tbody>
-                </table>
-
-                <hr />
-
-                <table class="form-table table table-borderless" role="presentation">
-                <h5>
-                    Database: Auth
-                </h5>
-                    <tbody>
-                        <tr>
-                            <th scope="row">
-                            <label for="acore_db_auth_host">IPv4:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_auth_host" value="<?= Opts::I()->acore_db_auth_host; ?>" size="20" placeholder="127.0.0.1">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_db_auth_port">Port:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_auth_port" value="<?= Opts::I()->acore_db_auth_port; ?>" size="20" placeholder="3306">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_db_auth_user">Username:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_auth_user" value="<?= Opts::I()->acore_db_auth_user; ?>" size="20" placeholder="acore">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_realm_alias">Password:</label>
-                            </th>
-                            <td>
-                                <input type="password" name="acore_db_auth_pass" value="<?= Opts::I()->acore_db_auth_pass; ?>" size="20" placeholder="acore">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_db_auth_name">Database Name:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_auth_name" value="<?= Opts::I()->acore_db_auth_name; ?>" size="20" placeholder="acore_auth">
-                            </td>
-                        </tr>
-                        <tr>
-                    </tbody>
-                </table>
-
-                <hr />
-
-                <table class="form-table table table-borderless" role="presentation">
-                <h5>
-                    Database: Characters
-                </h5>
-                    <tbody>
-                        <tr>
-                            <th scope="row">
-                                <label for="acore_db_char_host">IPv4:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_char_host" value="<?= Opts::I()->acore_db_char_host; ?>" size="20" placeholder="127.0.0.1">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_db_char_port">Port:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_char_port" value="<?= Opts::I()->acore_db_char_port; ?>" size="20" placeholder="3306">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_db_char_user">Username:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_char_user" value="<?= Opts::I()->acore_db_char_user; ?>" size="20" placeholder="acore">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_realm_alias">Password:</label>
-                            </th>
-                            <td>
-                                <input type="password" name="acore_db_char_pass" value="<?= Opts::I()->acore_db_char_pass; ?>" size="20" placeholder="acore">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_db_char_name">Database Name:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_char_name" value="<?= Opts::I()->acore_db_char_name; ?>" size="20" placeholder="acore_characters">
-                            </td>
-                        </tr>
-                        <tr>
-                    </tbody>
-                </table>
-
-            <hr />
-
-                <table class="form-table table table-borderless" role="presentation">
-                <h5>
-                    Database: World
-                </h5>
-                    <tbody>
-                        <tr>
-                            <th scope="row">
-                            <label for="acore_db_world_host">IPv4:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_world_host" value="<?= Opts::I()->acore_db_world_host; ?>" size="20" placeholder="127.0.0.1">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_db_world_port">Port:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_world_port" value="<?= Opts::I()->acore_db_world_port; ?>" size="20" placeholder="3306">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_db_world_user">Username:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_world_user" value="<?= Opts::I()->acore_db_world_user; ?>" size="20" placeholder="acore">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_realm_alias">Password:</label>
-                            </th>
-                            <td>
-                                <input type="password" name="acore_db_world_pass" value="<?= Opts::I()->acore_db_world_pass; ?>" size="20" placeholder="acore">
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>
-                                <label for="acore_db_world_name">Database Name:</label>
-                            </th>
-                            <td>
-                                <input type="text" name="acore_db_world_name" value="<?= Opts::I()->acore_db_world_name; ?>" size="20" placeholder="acore_world">
-                            </td>
-                        </tr>
-                        <tr>
-                    </tbody>
-                </table>
-            </div>
+                <h6>You will need to "Save Changes" above before checking your SOAP Configuration!</h6>
+            </form>
         </div>
 
-        <div id="ajax-message"></div>
+        <!-- Col 2: Modules list - compact, 1 column, shown when SOAP alive -->
+        <div style="flex:0 0 auto; display:none;" id="acore-modules-panel">
+            <div class="card">
+                <div class="card-body" style="min-width:180px;">
+                    <h5 style="margin-bottom:10px;">Modules</h5>
 
-        <p class="submit">
-            <input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e('Save Changes', Opts::I()->page_alias) ?>" />
-            <input type="button" name="check-soap" id="check-soap" class="button-secondary" value="<?php esc_attr_e('Check SOAP', Opts::I()->page_alias) ?>" />
-        </p>
-        <h6>
-            You will need to "Save Changes" above before checking your SOAP Configuration!
-        </h6>
+                    <!-- 1-column tag list -->
+                    <div id="acore-modules-list" style="display:flex; flex-direction:column; gap:4px; min-height:32px;">
+                        <?php foreach ($storedModules as $mod): ?>
+                            <span class="acore-module-tag"><?= esc_html($mod) ?></span>
+                        <?php endforeach; ?>
+                        <?php if (empty($storedModules)): ?>
+                            <span class="acore-modules-empty">No modules loaded.<br>Click Refresh.</span>
+                        <?php endif; ?>
+                    </div>
 
-    </form>
-</div>
+                    <!-- Refresh + last refreshed below list -->
+                    <div style="margin-top:12px; display:flex; flex-direction:column; gap:4px;">
+                        <button type="button" id="acore-modules-refresh" class="button button-secondary">Refresh</button>
+                        <span id="acore-modules-refreshed" style="font-size:11px; color:#8b949e;">
+                            <?php if ($modulesRefreshed): ?>
+                                Last refreshed:<br><?= wp_date('jS \o\f F, Y \a\t H:i', $modulesRefreshed) ?>
+                            <?php endif; ?>
+                        </span>
+                        <div id="acore-modules-autocheck" style="font-size:11px; margin-top:4px;"></div>
+                    </div>
+                </div>
+            </div>
+        </div><!-- /col2 modules -->
+
+        <!-- Col 3: Module Requirements validator - compact, hidden until SOAP alive -->
+        <div style="flex:0 0 auto; display:none;" id="acore-validate-panel">
+            <div class="card">
+                <div class="card-body" style="min-width:280px;">
+                    <h5 style="margin-bottom:4px;">Module Requirements</h5>
+                    <p style="font-size:12px; color:#646970; margin:0 0 10px;">
+                        Map a WooCommerce product name to the module it requires. The system
+                        checks if that module is active before allowing the purchase.
+                    </p>
+
+                    <table id="acore-req-table" style="width:100%; border-collapse:collapse; margin-bottom:8px;">
+                        <thead>
+                            <tr>
+                                <th style="text-align:left; font-size:12px; padding:0 4px 4px 0;">Product Name</th>
+                                <th style="text-align:left; font-size:12px; padding:0 0 4px 4px;">Module slug</th>
+                                <th style="width:24px;"></th>
+                            </tr>
+                        </thead>
+                        <tbody id="acore-req-tbody">
+                            <?php foreach ($storedRequirements as $req): ?>
+                            <tr>
+                                <td style="padding:2px 4px 2px 0;"><input type="text" class="req-product regular-text" style="width:100%;" value="<?= esc_attr($req[0]) ?>"></td>
+                                <td style="padding:2px 0 2px 4px;"><input type="text" class="req-module regular-text" style="width:100%;" value="<?= esc_attr($req[1]) ?>"></td>
+                                <td><button type="button" class="button button-link-delete req-remove" style="color:#a00;" title="Remove">&times;</button></td>
+                            </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+
+                    <div style="display:flex; gap:6px; flex-wrap:wrap; margin-bottom:8px;">
+                        <button type="button" id="acore-req-add" class="button button-secondary" style="font-size:12px; padding:2px 8px;">+ Add Row</button>
+                        <button type="button" id="acore-req-save" class="button button-primary" style="font-size:12px; padding:2px 8px;">Save</button>
+                    </div>
+                    <span id="acore-req-msg" style="font-size:12px;"></span>
+                </div>
+            </div>
+        </div><!-- /col3 validate -->
+
+    </div><!-- /flex row -->
+</div><!-- /wrap -->
 
 <script>
-    jQuery('#check-soap').on('click', function(e) {
-        jQuery('#ajax-message').html('');
-        jQuery.ajax({
-            url: "<?php echo get_rest_url(null, ACORE_SLUG . '/v1/server-info'); ?>",
-            success: function(response) {
-                jQuery('#ajax-message').html('<div class="notice notice-info"><p>SOAP Response: <strong>' + response.message + '</strong></p></div>');
-            },
-            error: function(response) {
-                jQuery('#ajax-message').html('<div class="notice notice-error"><p>An unknown error happens requesting SOAP status.</div>');
-            },
-        })
+(function($){
+    var restBase  = '<?= esc_js(rest_url(ACORE_SLUG . '/v1/')) ?>';
+    var nonce     = '<?= esc_js(wp_create_nonce('wp_rest')) ?>';
+    var $soapBtn  = $('#check-soap');
+    var $soapStat = $('#acore-soap-status');
+    var $modPanel = $('#acore-modules-panel');
+    var $valPanel = $('#acore-validate-panel');
+
+    var knownModules   = <?= wp_json_encode($storedModules) ?>;
+    var referencedSlugs = <?= wp_json_encode($referencedSlugs) ?>;
+    var autoCheckDone  = false;
+
+    function lc(arr) { return (arr || []).map(function(s){ return String(s).toLowerCase(); }); }
+
+    function diffReferenced(oldList, newList) {
+        var oldL = lc(oldList), newL = lc(newList), added = [], removed = [];
+        referencedSlugs.forEach(function(slug){
+            var s = String(slug).toLowerCase();
+            var wasIn = oldL.indexOf(s) !== -1;
+            var nowIn = newL.indexOf(s) !== -1;
+            if (nowIn && !wasIn) added.push(slug);
+            if (!nowIn && wasIn) removed.push(slug);
+        });
+        return { added: added, removed: removed };
+    }
+
+    function renderAutoCheck(diff) {
+        var $box = $('#acore-modules-autocheck').empty();
+        if (!referencedSlugs.length) return;
+        var now = new Date();
+        $box.append($('<div>').css({color:'#8b949e'})
+            .text('Automated module check at ' + now.toLocaleString()));
+        if (!diff.added.length && !diff.removed.length) {
+            $box.append($('<div>').css({color:'#8b949e'})
+                .text('• No changes to required modules.'));
+            return;
+        }
+        diff.removed.forEach(function(m){
+            $box.append($('<div>').css({color:'#da3633'}).text('• ' + m + ' removed'));
+        });
+        diff.added.forEach(function(m){
+            $box.append($('<div>').css({color:'#238636'}).text('• ' + m + ' added'));
+        });
+    }
+
+    /* ── SOAP check on page load ──────────────────────────────────────── */
+    function checkSoap(manual) {
+        if (manual) $soapBtn.prop('disabled', true).val('Checking…');
+        $.get(restBase + 'server-info', function(data) {
+            setSoapStatus(true);
+        }).fail(function() {
+            setSoapStatus(false);
+        }).always(function() {
+            if (manual) $soapBtn.prop('disabled', false).val('Check SOAP');
+        });
+    }
+
+    function setSoapStatus(ok) {
+        if ($soapStat.length) {
+            $soapStat.text(ok ? 'Connected' : 'Offline')
+                     .css('background', ok ? '#238636' : '#da3633');
+        }
+        if (ok) {
+            $modPanel.show();
+            $valPanel.show();
+            if (!autoCheckDone) {
+                autoCheckDone = true;
+                refreshModules({ auto: true });
+            }
+        } else {
+            $modPanel.hide();
+            $valPanel.hide();
+        }
+    }
+
+    checkSoap(false);
+    $soapBtn.on('click', function(){ checkSoap(true); });
+
+    /* ── Modules refresh ─────────────────────────────────────────────── */
+    function refreshModules(opts) {
+        opts = opts || {};
+        var $btn = opts.auto ? null : $('#acore-modules-refresh').prop('disabled', true).text('Refreshing…');
+        return $.ajax({
+            url: restBase + 'server-modules', method: 'POST',
+            beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', nonce); }
+        }).done(function(res){
+            var newModules = (res.modules || []);
+
+            if (!opts.auto) {
+                var $list = $('#acore-modules-list').empty();
+                if (newModules.length) {
+                    newModules.forEach(function(m){
+                        $list.append($('<span>').addClass('acore-module-tag').text(m));
+                    });
+                } else {
+                    $list.append($('<span>').addClass('acore-modules-empty').text('No modules found.'));
+                }
+                var d = new Date(res.refreshed * 1000);
+                $('#acore-modules-refreshed').html('Last refreshed:<br>' + d.toLocaleString());
+            }
+
+            renderAutoCheck(diffReferenced(knownModules, newModules));
+            knownModules = newModules;
+        }).fail(function(){
+            if (!opts.auto) {
+                alert('Failed to refresh modules. Is SOAP configured and the server running?');
+            }
+        }).always(function(){
+            if ($btn) $btn.prop('disabled', false).text('Refresh');
+        });
+    }
+
+    $('#acore-modules-refresh').on('click', function(){ refreshModules({ auto: false }); });
+
+    /* ── Module Requirements ─────────────────────────────────────────── */
+    function addReqRow(product, module) {
+        var row = $('<tr>').append(
+            $('<td style="padding:2px 4px 2px 0;">').append($('<input type="text" class="req-product regular-text" style="width:100%;">').val(product || '')),
+            $('<td style="padding:2px 0 2px 4px;">').append($('<input type="text" class="req-module regular-text" style="width:100%;">').val(module || '')),
+            $('<td>').append($('<button type="button" class="button button-link-delete req-remove" style="color:#a00;" title="Remove">').text('×'))
+        );
+        $('#acore-req-tbody').append(row);
+    }
+
+    $('#acore-req-add').on('click', function(){ addReqRow('', ''); });
+
+    $(document).on('click', '.req-remove', function(){ $(this).closest('tr').remove(); });
+
+    $('#acore-req-save').on('click', function(){
+        var $btn = $(this).prop('disabled', true).text('Saving…');
+        var $msg = $('#acore-req-msg');
+        var reqs = [];
+        $('#acore-req-tbody tr').each(function(){
+            var p = $(this).find('.req-product').val().trim();
+            var m = $(this).find('.req-module').val().trim();
+            if (p && m) reqs.push([p, m]);
+        });
+        $.ajax({
+            url: restBase + 'server-module-requirements', method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({ requirements: reqs }),
+            beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', nonce); }
+        }).done(function(){
+            referencedSlugs = reqs.map(function(req){ return req[1]; });
+            $msg.css('color', '#238636').text('Saved!');
+            setTimeout(function(){ $msg.text(''); }, 3000);
+        }).fail(function(){
+            $msg.css('color', '#da3633').text('Save failed.');
+        }).always(function(){
+            $btn.prop('disabled', false).text('Save');
+        });
     });
+
+    /* ── Settings form AJAX save ─────────────────────────────────────── */
+    $('form[name="form-acore-settings"]').on('submit', function(e){
+        e.preventDefault();
+        var $msg = $('#ajax-message');
+        $msg.html('<p>Saving…</p>');
+        $.post(window.location.href, $(this).serialize() + '&noheader=true', function(){
+            $msg.html('<div class="notice notice-success"><p>Settings saved.</p></div>');
+        }).fail(function(){
+            $msg.html('<div class="notice notice-error"><p>Save failed.</p></div>');
+        });
+    });
+
+})(jQuery);
 </script>

--- a/src/acore-wp-plugin/src/Components/AdminPanel/Pages/Tools.php
+++ b/src/acore-wp-plugin/src/Components/AdminPanel/Pages/Tools.php
@@ -1,16 +1,83 @@
 <?php
     use ACore\Manager\Opts;
+    $modulesCsv         = get_option('acore_modules_csv', '');
+    $installedModules   = $modulesCsv ? array_map('trim', explode(',', $modulesCsv)) : [];
+    $hasResurrectionMod = in_array('mod-resurrection-scroll', $installedModules);
+
+    // If module is missing, treat as disabled for UI purposes
+    $scrollEnabled = $hasResurrectionMod && Opts::I()->acore_resurrection_scroll == '1';
 ?>
 
 <style>
-    .acore-btn-danger {
-        border-color: #d63638 !important;
-        color: #d63638 !important;
-        background: #f7f6f6 !important;
+    /* .acore-btn-danger styling lives in theme.css (shared light/dark) */
+    .acore-days-inactive-disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+    }
+    .acore-days-inactive-disabled input,
+    .acore-days-inactive-disabled select {
+        pointer-events: none;
     }
 
-    .acore-btn-danger .dashicons {
-        margin-top: 3px;
+    /* Missing module: greyed select + hover tooltip */
+    .acore-missing-module-wrap {
+        position: relative;
+        display: inline-block;
+    }
+    .acore-missing-module-wrap select[disabled] {
+        opacity: 0.45;
+        cursor: not-allowed;
+        pointer-events: none;
+    }
+    .acore-missing-module-tooltip {
+        display: none;
+        position: absolute;
+        bottom: calc(100% + 6px);
+        left: 0;
+        background: #1c2128;
+        color: #c9d1d9;
+        font-size: 12px;
+        padding: 6px 10px;
+        border-radius: 4px;
+        white-space: nowrap;
+        z-index: 100;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+    }
+    .acore-missing-module-wrap:hover .acore-missing-module-tooltip { display: block; }
+
+    /* Confirm modal (defaults to "No") */
+    .acore-modal-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.45);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 100000;
+    }
+    .acore-modal-box {
+        background: #fff;
+        color: #1d2327;
+        max-width: 420px;
+        width: calc(100% - 40px);
+        padding: 20px;
+        border-radius: 6px;
+        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
+    }
+    body.acore-dark-mode .acore-modal-box {
+        background: #1c2128;
+        color: #c9d1d9;
+    }
+    .acore-modal-text {
+        font-size: 13px;
+        line-height: 1.5;
+        white-space: pre-line;
+        margin: 0 0 16px;
+    }
+    .acore-modal-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
     }
 </style>
 
@@ -21,20 +88,19 @@
             <h2>Tools</h2>
             <hr>
             <form method="post">
+                <?php wp_nonce_field('acore_tools_save', 'acore_tools_nonce'); ?>
                 <div class="row">
-                    <div class="col-sm-3">
+
+                    <!-- Col 1: World Server Integration -->
+                    <div class="col-sm-4">
                         <div class="card p-0">
                             <div class="card-body">
-                                <h5>
-                                    Worldserver integration
-                                </h5>
+                                <h5>World Server Integration</h5>
                                 <hr>
                                 <table class="form-table table table-borderless" role="presentation">
                                     <tbody>
                                         <tr>
-                                            <th>
-                                                <label for="acore_item_restoration">Item Restoration Service</label>
-                                            </th>
+                                            <th><label class="acore-help-label" title="Lets players restore recently deleted items to their characters via in-game mail.">Item Restoration Service</label></th>
                                             <td>
                                                 <select name="acore_item_restoration" id="acore_item_restoration">
                                                     <option value="0">Disabled</option>
@@ -44,21 +110,45 @@
                                         </tr>
                                         <tr>
                                             <th>
-                                                <label for="acore_resurrection_scroll">Scroll of Resurrection</label>
+                                                <?php if (!$hasResurrectionMod): ?>
+                                                    <span class="acore-missing-module-wrap">
+                                                        <label class="acore-help-label" style="color:#d63638;" title="Allows inactive characters to be restored via the Scroll of Resurrection module.">Scroll of Resurrection</label>
+                                                        <span class="acore-missing-module-tooltip">Requires module mod-resurrection-scroll</span>
+                                                    </span>
+                                                <?php else: ?>
+                                                    <label class="acore-help-label" title="Allows inactive characters to be restored via the Scroll of Resurrection module.">Scroll of Resurrection</label>
+                                                <?php endif; ?>
                                             </th>
                                             <td>
-                                                <select name="acore_resurrection_scroll" id="acore_resurrection_scroll">
-                                                    <option value="0">Disabled</option>
-                                                    <option value="1" <?php if (Opts::I()->acore_resurrection_scroll == '1') echo 'selected'; ?>>Enabled</option>
-                                                </select>
+                                                <?php if (!$hasResurrectionMod): ?>
+                                                    <input type="hidden" name="acore_resurrection_scroll" value="0">
+                                                    <span class="acore-missing-module-wrap">
+                                                        <select name="acore_resurrection_scroll" id="acore_resurrection_scroll" disabled>
+                                                            <option value="0">Disabled</option>
+                                                        </select>
+                                                        <span class="acore-missing-module-tooltip">Requires module mod-resurrection-scroll</span>
+                                                    </span>
+                                                <?php else: ?>
+                                                    <select name="acore_resurrection_scroll" id="acore_resurrection_scroll">
+                                                        <option value="0">Disabled</option>
+                                                        <option value="1" <?php if ($scrollEnabled) echo 'selected'; ?>>Enabled</option>
+                                                    </select>
+                                                <?php endif; ?>
                                             </td>
                                         </tr>
-                                        <tr class="acore_resurrection_scroll_config" <?php if (Opts::I()->acore_resurrection_scroll != '1') echo 'style="display:none;"'?>>
-                                            <th>
-                                                <label for="acore_resurrection_scroll_days_inactive">Days Inactive</label>
-                                            </th>
+                                        <tr>
+                                            <th><label class="acore-help-label" title="How many days a character must be inactive before a Scroll of Resurrection can target it.">Days Inactive</label></th>
                                             <td>
-                                                <input type="number" name="acore_resurrection_scroll_days_inactive" id="acore_resurrection_scroll_days_inactive" min="1" value="<?= esc_attr(Opts::I()->acore_resurrection_scroll_days_inactive) ?>">
+                                                <span id="acore-days-inactive-wrap"
+                                                      class="<?= !$scrollEnabled ? 'acore-days-inactive-disabled' : '' ?>"
+                                                      title="<?= !$scrollEnabled ? 'Scroll of Resurrection must be enabled' : '' ?>">
+                                                    <input type="number"
+                                                           name="acore_resurrection_scroll_days_inactive"
+                                                           id="acore_resurrection_scroll_days_inactive"
+                                                           min="1"
+                                                           value="<?= esc_attr(Opts::I()->acore_resurrection_scroll_days_inactive) ?>"
+                                                           <?= !$scrollEnabled ? 'disabled' : '' ?>>
+                                                </span>
                                             </td>
                                         </tr>
                                     </tbody>
@@ -67,91 +157,448 @@
                         </div>
                     </div>
 
-                    <div class="col-sm-3">
+                    <!-- Col 2: Web Integration -->
+                    <div class="col-sm-4">
                         <div class="card p-0">
                             <div class="card-body">
-                                <h5>
-                                    Name Unlock Settings
-                                </h5>
+                                <h5>Web Integration</h5>
+                                <hr>
+                                <table class="form-table table table-borderless" role="presentation">
+                                    <tbody>
+                                        <tr>
+                                            <th><label class="acore-help-label" title="Records each website login (IP, country, date) and the account's last in-game IP for the Recent Connections view.">Security Logging</label></th>
+                                            <td>
+                                                <select name="acore_security_logging" id="acore_security_logging">
+                                                    <option value="0" <?php if (Opts::I()->acore_security_logging != '1') echo 'selected'; ?>>Disabled</option>
+                                                    <option value="1" <?php if (Opts::I()->acore_security_logging == '1') echo 'selected'; ?>>Enabled</option>
+                                                </select>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <th><label class="acore-help-label" title="When enabled, login IPs are sent to ip-api.com to resolve their country. Disabled keeps IPs in-house (country shows as Unknown). Backfills older Unknown entries in the background within ip-api's free rate limit.">GeoIP Country Lookup</label></th>
+                                            <td>
+                                                <?php if (Opts::I()->acore_security_logging != '1'): ?>
+                                                    <input type="hidden" name="acore_geoip_lookup" value="0">
+                                                <?php endif; ?>
+                                                <span id="acore-geoip-wrap"
+                                                      class="<?= Opts::I()->acore_security_logging != '1' ? 'acore-days-inactive-disabled' : '' ?>"
+                                                      title="<?= Opts::I()->acore_security_logging != '1' ? 'Security Logging must be enabled' : '' ?>">
+                                                    <select name="acore_geoip_lookup" id="acore_geoip_lookup" <?= Opts::I()->acore_security_logging != '1' ? 'disabled' : '' ?>>
+                                                        <option value="0" <?php if (Opts::I()->acore_geoip_lookup != '1') echo 'selected'; ?>>Disabled</option>
+                                                        <option value="1" <?php if (Opts::I()->acore_geoip_lookup == '1') echo 'selected'; ?>>Enabled</option>
+                                                    </select>
+                                                </span>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <th><label class="acore-help-label" title="If disabled, users cannot reuse any of their last 10 passwords when changing it.">Allow Old Passwords</label></th>
+                                            <td>
+                                                <select name="acore_allow_old_passwords" id="acore_allow_old_passwords">
+                                                    <option value="0" <?php if (Opts::I()->acore_allow_old_passwords != '1') echo 'selected'; ?>>Disabled</option>
+                                                    <option value="1" <?php if (Opts::I()->acore_allow_old_passwords == '1') echo 'selected'; ?>>Enabled</option>
+                                                </select>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+
+                                <hr style="margin:12px 0;">
+
+                                <!-- Remove 2FA -->
+                                <p style="font-weight:600; margin:0 0 4px; font-size:13px;">Remove 2FA</p>
+                                <p style="font-size:12px; color:#646970; margin:0 0 12px;">
+                                    Remove Website or In-game 2FA for any account. A warning is shown to the user until they re-enable it.
+                                </p>
+
+                                <!-- Website 2FA -->
+                                <p style="font-size:12px; font-weight:600; margin:0 0 4px;">Website</p>
+                                <div style="display:flex; gap:6px; align-items:center; margin-bottom:6px; flex-wrap:wrap;">
+                                    <input type="text" id="acore-2fa-web-user" placeholder="Account name" style="flex:1 1 120px; min-width:80px;">
+                                    <button type="button" id="acore-2fa-web-check" class="button button-secondary" style="white-space:nowrap;">Check</button>
+                                    <button type="button" id="acore-2fa-web-remove" class="button acore-btn-danger" style="white-space:nowrap;" disabled>Remove</button>
+                                </div>
+                                <p id="acore-2fa-web-msg" style="font-size:12px; margin:0 0 12px; min-height:18px;"></p>
+
+                                <!-- Backup codes (always visible; greyed until a Website check finds codes) -->
+                                <div id="acore-backup-wrap" style="margin:0 0 12px; opacity:0.45;">
+                                    <p style="font-size:12px; font-weight:600; margin:0 0 4px;">Backup Codes</p>
+                                    <span id="acore-backup-info" style="font-size:12px;">Check a Website account above to view backup codes.</span>
+                                    <button type="button" id="acore-backup-remove" class="button acore-btn-danger" style="white-space:nowrap; margin-left:6px;" disabled>Remove backup codes</button>
+                                </div>
+
+                                <!-- In-game 2FA -->
+                                <p style="font-size:12px; font-weight:600; margin:0 0 4px;">In-Game</p>
+                                <div style="display:flex; gap:6px; align-items:center; margin-bottom:6px; flex-wrap:wrap;">
+                                    <input type="text" id="acore-2fa-game-user" placeholder="Account name" style="flex:1 1 120px; min-width:80px;">
+                                    <button type="button" id="acore-2fa-game-check" class="button button-secondary" style="white-space:nowrap;">Check</button>
+                                    <button type="button" id="acore-2fa-game-remove" class="button acore-btn-danger" style="white-space:nowrap;" disabled>Remove</button>
+                                </div>
+                                <p id="acore-2fa-game-msg" style="font-size:12px; margin:0 0 4px; min-height:18px;"></p>
+
+                            </div><!-- /card-body Web Integration -->
+                        </div><!-- /card Web Integration -->
+                    </div><!-- /col2 -->
+
+                    <!-- Col 3: Name Unlock Settings -->
+                    <div class="col-sm-4">
+                        <div class="card p-0">
+                            <div class="card-body">
+                                <h5>Name Unlock Settings</h5>
                                 <hr>
 
                                 <span>Allowed banned names table (characters database):</span>
                                 <input type="text" name="acore_name_unlock_allowed_banned_names_table"
                                     value="<?= Opts::I()->acore_name_unlock_allowed_banned_names_table ?>">
-                                <br>
-                                <br>
+                                <br><br>
 
                                 <span>Inactivity Thresholds per Level:</span>
                                 <table id="acore-name-unlock-thresholds" class="form-table table table-borderless" role="presentation">
                                     <thead>
                                         <tr>
-                                            <th>Max Level (<)</th>
+                                            <th>Max Level (&lt;)</th>
                                             <th>Minimum Days of Inactivity</th>
                                         </tr>
                                     </thead>
                                     <tbody></tbody>
                                 </table>
-                                <div id="acore-name-unlock-thresholds-add" class="button"><span class="dashicons dashicons-plus" style="margin-top: 5px;"></span> Add</div>
+                                <div style="display:flex; gap:6px; margin-top:4px;">
+                                    <div id="acore-name-unlock-thresholds-add" class="button">
+                                        <span class="dashicons dashicons-plus" style="margin-top:5px;"></span> Add
+                                    </div>
+                                    <div id="acore-name-unlock-reset" class="button acore-btn-danger" title="Reset Name Unlock to defaults">
+                                        <span class="dashicons dashicons-image-rotate" style="margin-top:5px;"></span> Reset
+                                    </div>
+                                </div>
                             </div>
                         </div>
+                    </div><!-- /col3 -->
+
+                </div><!-- /row -->
+
+                <!-- User Login History (admin lookup) -->
+                <div class="card p-0" style="margin-top:16px;">
+                    <div class="card-body">
+                        <h5>User Login History</h5>
+                        <hr>
+                        <p style="font-size:12px; color:#646970; margin:0 0 8px;">
+                            Look up the recorded login IP history for any account (the same list the user sees on their Security page).
+                        </p>
+                        <div style="display:flex; gap:6px; align-items:center; margin-bottom:10px; flex-wrap:wrap;">
+                            <input type="text" id="acore-history-user" placeholder="Account name" style="flex:0 1 220px;">
+                            <button type="button" id="acore-history-lookup" class="button button-secondary">Look up</button>
+                        </div>
+                        <p id="acore-history-msg" style="font-size:12px; margin:0 0 8px; min-height:18px;"></p>
+                        <table id="acore-history-table" class="wp-list-table widefat fixed striped" style="display:none; max-width:760px;">
+                            <thead>
+                                <tr><th>IPv4 Address</th><th>Country</th><th>Date / Time</th><th>Where</th></tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                        <p style="margin-top:8px;">
+                            <button type="button" id="acore-history-more" class="button" style="display:none;">See more</button>
+                        </p>
                     </div>
                 </div>
 
-                <div class="submit">
-                    <input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e('Save Changes', Opts::I()->page_alias) ?>" />
-                </div>
+                <p class="submit">
+                    <input type="submit" name="Submit" class="button-primary" value="<?php esc_attr_e('Save Changes', Opts::I()->page_alias) ?>">
+                </p>
             </form>
         </div>
     </div>
 </div>
 
+<!-- Reusable confirm modal (default button is "No") -->
+<div id="acore-confirm-modal" class="acore-modal-overlay" style="display:none;">
+    <div class="acore-modal-box">
+        <p id="acore-confirm-modal-text" class="acore-modal-text"></p>
+        <div class="acore-modal-actions">
+            <button type="button" id="acore-confirm-yes" class="button acore-btn-danger">Yes</button>
+            <button type="button" id="acore-confirm-no" class="button button-secondary">No</button>
+        </div>
+    </div>
+</div>
+
 <script>
+(function($){
+    var restBase = '<?= esc_js(rest_url(ACORE_SLUG . '/v1/')) ?>';
+    var nonce    = '<?= esc_js(wp_create_nonce('wp_rest')) ?>';
+
+    /* Re-enable the Days Inactive input when scroll is toggled on */
+    $('#acore_resurrection_scroll').on('change', function(){
+        var on = $(this).val() === '1';
+        var $wrap = $('#acore-days-inactive-wrap');
+        $wrap.toggleClass('acore-days-inactive-disabled', !on)
+             .attr('title', on ? '' : 'Scroll of Resurrection must be enabled');
+        $('#acore_resurrection_scroll_days_inactive').prop('disabled', !on);
+    });
+
+    /* GeoIP depends on Security Logging being enabled */
+    $('#acore_security_logging').on('change', function(){
+        var on = $(this).val() === '1';
+        $('#acore-geoip-wrap').toggleClass('acore-days-inactive-disabled', !on)
+             .attr('title', on ? '' : 'Security Logging must be enabled');
+        $('#acore_geoip_lookup').prop('disabled', !on);
+    });
+
+    /* ── 2FA helpers ──────────────────────────────────────────────────── */
+    function ajaxPost(endpoint, body) {
+        return $.ajax({
+            url: restBase + endpoint,
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify(body),
+            beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', nonce); }
+        });
+    }
+
+    function wire2fa(type, $userInput, $check, $remove, $msg, onCheck) {
+        var checkedUsername = '';
+
+        $userInput.on('input', function(){
+            checkedUsername = '';
+            $remove.prop('disabled', true);
+        });
+
+        $check.on('click', function(){
+            var username = $userInput.val().trim();
+            if (!username) { $msg.css('color','#d63638').text('Enter an account name first.'); return; }
+            $check.prop('disabled', true).text('Checking…');
+            $remove.prop('disabled', true);
+            ajaxPost('admin/2fa-check', { type: type, username: username })
+                .done(function(data){
+                    if (!data.active) {
+                        var txt = '2FA is not active for ' + data.username + '.';
+                        if (data.last_removal) {
+                            var lr  = data.last_removal;
+                            var who = (lr.by === 'self') ? 'the user themselves' : (lr.staff || 'an administrator');
+                            txt += ' Last removed on ' + lr.date + ' by ' + who;
+                            if (lr.by === 'self' && lr.ip) { txt += ' (IP ' + lr.ip + ')'; }
+                            txt += '.';
+                        }
+                        checkedUsername = '';
+                        $msg.css('color','#d63638').text(txt);
+                        $remove.prop('disabled', true);
+                    } else {
+                        checkedUsername = data.username || username;
+                        $msg.css('color','#238636').text('2FA is active for ' + data.username + '.');
+                        $remove.prop('disabled', false);
+                    }
+                    if (typeof onCheck === 'function') onCheck(data, checkedUsername);
+                })
+                .fail(function(xhr){
+                    var err = xhr.responseJSON ? (xhr.responseJSON.message || JSON.stringify(xhr.responseJSON)) : 'Error.';
+                    $msg.css('color','#d63638').text(err);
+                    $remove.prop('disabled', true);
+                })
+                .always(function(){
+                    $check.prop('disabled', false).text('Check');
+                });
+        });
+
+        $remove.on('click', function(){
+            var username = checkedUsername;
+            if (!username) return;
+            if (!confirm('Remove ' + type + ' 2FA for ' + username + '? This cannot be undone.')) return;
+            $remove.prop('disabled', true).text('Removing…');
+            $check.prop('disabled', true);
+            ajaxPost('admin/2fa-remove', { type: type, username: username })
+                .done(function(data){
+                    $msg.css('color','#238636')
+                        .text('Removed on ' + data.date + ' by ' + data.staff + '. User will see a warning until they re-enable 2FA.');
+                    $remove.prop('disabled', true);
+                })
+                .fail(function(xhr){
+                    var err = xhr.responseJSON ? (xhr.responseJSON.message || JSON.stringify(xhr.responseJSON)) : 'Error.';
+                    $msg.css('color','#d63638').text(err);
+                    $remove.prop('disabled', false);
+                })
+                .always(function(){
+                    $check.prop('disabled', false).text('Check');
+                    if ($remove.text() === 'Removing…') $remove.text('Remove');
+                });
+        });
+    }
+
+    var webCheckedUsername = '';
+    wire2fa('website', $('#acore-2fa-web-user'),  $('#acore-2fa-web-check'),  $('#acore-2fa-web-remove'),  $('#acore-2fa-web-msg'), function(data, username){
+        webCheckedUsername = username || '';
+        var count = parseInt(data.backup_codes, 10) || 0;
+        if (count > 0 && webCheckedUsername) {
+            $('#acore-backup-wrap').css('opacity', '1');
+            $('#acore-backup-info').css('color','#646970').text(count + ' unused backup code' + (count === 1 ? '' : 's') + ' remaining.');
+            $('#acore-backup-remove').prop('disabled', false);
+        } else {
+            $('#acore-backup-wrap').css('opacity', '0.45');
+            $('#acore-backup-info').css('color','#646970').text(count > 0 ? 'Verify the account again to manage backup codes.' : 'No backup codes generated for this account.');
+            $('#acore-backup-remove').prop('disabled', true);
+        }
+    });
+    $('#acore-2fa-web-user').on('input', function(){ webCheckedUsername = ''; $('#acore-backup-remove').prop('disabled', true); });
+    wire2fa('ingame',  $('#acore-2fa-game-user'), $('#acore-2fa-game-check'), $('#acore-2fa-game-remove'), $('#acore-2fa-game-msg'));
+
+    /* Remove backup codes (uses the Website account-name input) */
+    $('#acore-backup-remove').on('click', function(){
+        var username = webCheckedUsername;
+        if (!username) { return; }
+        var $btn = $(this);
+        acoreConfirm('Remove all backup codes for ' + username + '? They will need to generate new ones.', function(){
+            $btn.prop('disabled', true).text('Removing…');
+            ajaxPost('admin/backup-codes-remove', { username: username })
+                .done(function(data){
+                    $('#acore-backup-info').css('color','#238636').text('Backup codes removed on ' + data.date + '. The user has been notified.');
+                })
+                .fail(function(xhr){
+                    var err = xhr.responseJSON ? (xhr.responseJSON.message || 'Error.') : 'Error.';
+                    $('#acore-backup-info').css('color','#d63638').text(err);
+                    $btn.prop('disabled', false);
+                })
+                .always(function(){ $btn.text('Remove backup codes'); });
+        });
+    });
+
+    /* User Login History lookup */
+    var acoreHistory = { username: '', page: 0, total: 0, shown: 0 };
+
+    function acoreHistoryFetch(page) {
+        var $tbl = $('#acore-history-table'), $tb = $tbl.find('tbody'),
+            $msg = $('#acore-history-msg'), $more = $('#acore-history-more');
+        return ajaxPost('admin/login-history', {
+                username: acoreHistory.username,
+                page:     page
+            })
+            .done(function(data){
+                var rows = data.history || [];
+                if (page === 1) { $tb.empty(); acoreHistory.shown = 0; acoreHistory.total = data.total || 0; }
+                if (page === 1 && !rows.length) {
+                    $tbl.hide(); $more.hide();
+                    $msg.css('color','#646970').text('No login history recorded for ' + data.username + '.');
+                    return;
+                }
+                rows.forEach(function(r){
+                    $('<tr>').append(
+                        $('<td>').text(r.ip),
+                        $('<td>').text(r.country),
+                        $('<td>').text(r.date),
+                        $('<td>').text(r.where)
+                    ).appendTo($tb);
+                });
+                acoreHistory.shown += rows.length;
+                acoreHistory.page   = data.page || page;
+                acoreHistory.total  = data.total || acoreHistory.total;
+                $tbl.show();
+                $msg.css('color','#646970').text('Showing ' + acoreHistory.shown + ' of ' + acoreHistory.total + ' for ' + data.username + '.');
+                $more.toggle(!!data.has_more);
+            })
+            .fail(function(xhr){
+                if (page === 1) { $tbl.hide(); $more.hide(); }
+                var err = xhr.responseJSON ? (xhr.responseJSON.message || 'Error.') : 'Error.';
+                $msg.css('color','#d63638').text(err);
+            });
+    }
+
+    $('#acore-history-lookup').on('click', function(){
+        var username = $('#acore-history-user').val().trim();
+        if (!username) { $('#acore-history-msg').css('color','#d63638').text('Enter an account name first.'); return; }
+        acoreHistory.username = username;
+        $('#acore-history-msg').css('color','#646970').text('');
+        var $btn = $(this).prop('disabled', true).text('Looking up…');
+        acoreHistoryFetch(1).always(function(){ $btn.prop('disabled', false).text('Look up'); });
+    });
+
+    $('#acore-history-more').on('click', function(){
+        var $b = $(this).prop('disabled', true).text('Loading…');
+        acoreHistoryFetch(acoreHistory.page + 1).always(function(){ $b.prop('disabled', false).text('See more'); });
+    });
+
+    /* ── Name Unlock Thresholds ───────────────────────────────────────── */
     const deleteThreshold = (ev) => {
-        const $ = jQuery;
-        const $btn = $(ev.target);
-        const $tr = $btn.closest("tr");
-        $tr.remove();
-
-        const $trs = $("#acore-name-unlock-thresholds tbody tr");
-        let i = 0;
-        for (const tr of $trs) {
-            const previ = $(tr).data("i");
-            $(tr).data("i", i);
-            $(tr).find(`input[name="acore_name_unlock_thresholds[${previ}][0]"]`).attr("name", `acore_name_unlock_thresholds[${i}][0]`);
-            $(tr).find(`input[name="acore_name_unlock_thresholds[${previ}][1]"]`).attr("name", `acore_name_unlock_thresholds[${i}][1]`);
-            ++i;
-        }
+        const $btn = $(ev.target).closest('.acore-btn-danger');
+        const $tr  = $btn.closest('tr');
+        acoreConfirm('Remove this inactivity threshold row?', function () {
+            $tr.remove();
+            let i = 0;
+            $('#acore-name-unlock-thresholds tbody tr').each(function () {
+                const previ = $(this).data('i');
+                $(this).data('i', i);
+                $(this).find(`input[name="acore_name_unlock_thresholds[${previ}][0]"]`).attr('name', `acore_name_unlock_thresholds[${i}][0]`);
+                $(this).find(`input[name="acore_name_unlock_thresholds[${previ}][1]"]`).attr('name', `acore_name_unlock_thresholds[${i}][1]`);
+                i++;
+            });
+        });
     };
 
-    const addThreshold = (i = undefined, level = "", days = "") => {
-        const $ = jQuery;
-
+    const addThreshold = (i = undefined, level = '', days = '') => {
         if (i === undefined) {
-            const $trs = $("#acore-name-unlock-thresholds tbody tr");
-            i = $($trs[$trs.length - 1]).data("i") + 1;
+            const $trs = $('#acore-name-unlock-thresholds tbody tr');
+            i = $trs.length ? $($trs[$trs.length - 1]).data('i') + 1 : 0;
         }
-
-        const $tr = $("<tr>").appendTo("#acore-name-unlock-thresholds tbody");
-        $tr.data("i", i);
-        let $td = $("<td>").appendTo($tr);
-        $(`<input type="number" name="acore_name_unlock_thresholds[${i}][0]" min="1" max="256" value="${level}">`).appendTo($td);
-        $td = $("<td>").appendTo($tr);
-        $(`<input type="number" name="acore_name_unlock_thresholds[${i}][1]" min="1" value="${days}">`).appendTo($td);
-        $td = $("<td>").appendTo($tr);
-        const $btnDel = $(`<div class="button acore-btn-danger acore-name-unlock-thresholds-delete">`).appendTo($td);
+        const $tr = $('<tr>').appendTo('#acore-name-unlock-thresholds tbody');
+        $tr.data('i', i);
+        let $td = $('<td>').appendTo($tr);
+        $('<input>', { type: 'number', name: `acore_name_unlock_thresholds[${i}][0]`, min: 1, max: 256 }).val(level).appendTo($td);
+        $td = $('<td>').appendTo($tr);
+        $('<input>', { type: 'number', name: `acore_name_unlock_thresholds[${i}][1]`, min: 1 }).val(days).appendTo($td);
+        $td = $('<td>').appendTo($tr);
+        const $btnDel = $(`<div class="button acore-btn-danger">`).appendTo($td);
         $btnDel.append(`<span class="dashicons dashicons-trash"></span>`);
-        $btnDel.on("click", deleteThreshold);
+        $btnDel.on('click', deleteThreshold);
     };
 
-    jQuery("#acore-name-unlock-thresholds-add").on("click", () => addThreshold());
+    $('#acore-name-unlock-thresholds-add').on('click', () => addThreshold());
 
-    jQuery('#acore_resurrection_scroll').on('change', function() {
-        jQuery('.acore_resurrection_scroll_config').toggle();
+    /* ── Confirm modal (Yes / No; doing nothing = no action) ─────────── */
+    function acoreConfirm(message, onConfirm) {
+        const $overlay = $('#acore-confirm-modal');
+        $('#acore-confirm-modal-text').text(message);
+        $overlay.css('display', 'flex');
+        // Nothing is auto-focused: if the user does nothing (Escape / click
+        // outside), nothing happens - they must explicitly click Yes or No.
+
+        const close = () => {
+            $overlay.hide();
+            $('#acore-confirm-yes').off('click.acoreConfirm');
+            $('#acore-confirm-no').off('click.acoreConfirm');
+            $overlay.off('click.acoreConfirm');
+            $(document).off('keydown.acoreConfirm');
+        };
+
+        $('#acore-confirm-yes').on('click.acoreConfirm', function () {
+            close();
+            onConfirm();
+        });
+        $('#acore-confirm-no').on('click.acoreConfirm', close);
+        // Click outside the box = No.
+        $overlay.on('click.acoreConfirm', function (e) {
+            if (e.target === this) close();
+        });
+        // Escape = No.
+        $(document).on('keydown.acoreConfirm', function (e) {
+            if (e.key === 'Escape') close();
+        });
+    }
+
+    /* ── Reset Name Unlock to Defaults ──────────────────────────────── */
+    $('#acore-name-unlock-reset').on('click', function () {
+        acoreConfirm(
+            'Reset Name Unlock settings to defaults?\n\n' +
+            'This will clear the banned names table and delete all inactivity thresholds.\n\n' +
+            'This cannot be undone. Continue?',
+            function () {
+                $('input[name="acore_name_unlock_allowed_banned_names_table"]').val('');
+                $('#acore-name-unlock-thresholds tbody tr').remove();
+                $('input[name="Submit"]').closest('form').submit();
+            }
+        );
     });
 
     <?php foreach (Opts::I()->acore_name_unlock_thresholds as $i => $threshold) {
-        if ($threshold[0] != "" && $threshold[1] != "") {
-            echo "addThreshold($i, $threshold[0], $threshold[1]);";
+        $level = isset($threshold[0]) ? filter_var($threshold[0], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => 256]]) : false;
+        $days  = isset($threshold[1]) ? filter_var($threshold[1], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) : false;
+        if ($level !== false && $days !== false) {
+            echo 'addThreshold(' . wp_json_encode((int) $i) . ', ' . wp_json_encode($level) . ', ' . wp_json_encode($days) . ');';
         }
     } ?>
+
+})(jQuery);
 </script>

--- a/src/acore-wp-plugin/src/Components/AdminPanel/SettingsController.php
+++ b/src/acore-wp-plugin/src/Components/AdminPanel/SettingsController.php
@@ -44,6 +44,8 @@ class SettingsController {
             // If they did, this hidden field will be set to 'Y'
 
             if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+                check_admin_referer('acore_realm_settings_save', 'acore_realm_settings_nonce');
+
                 foreach (Opts::I()->getConfs() as $key => $value) {
                     if (isset($_POST[$key])) {
                         $this->storeConf($key, $_POST[$key]);
@@ -84,6 +86,8 @@ class SettingsController {
             // If they did, this hidden field will be set to 'Y'
 
             if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+                check_admin_referer('acore_eluna_settings_save', 'acore_eluna_settings_nonce');
+
                 foreach (Opts::I()->getConfs() as $key => $value) {
                     if (isset($_POST[$key])) {
                         $this->storeConf($key, $_POST[$key]);
@@ -131,6 +135,7 @@ class SettingsController {
         //! DEV NOTE: Put the rest of stuff within try { ... } check to handle every exception properly
         try {
             if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+                check_admin_referer('acore_pvp_rewards_save', 'acore_pvp_rewards_nonce');
                 global $wpdb;
                 $tableResult = $wpdb->query("CREATE TEMPORARY TABLE temp_pvp_rewards (
                 `account` VARCHAR(255) COLLATE utf8_unicode_ci,
@@ -385,6 +390,8 @@ class SettingsController {
         //! DEV NOTE: Put the rest of stuff within try { ... } check to handle every exception properly
         try {
             if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+                check_admin_referer('acore_tools_save', 'acore_tools_nonce');
+
                 foreach (Opts::I()->getConfs() as $key => $value) {
                     if (isset($_POST[$key])) {
                         if ($key == 'acore_name_unlock_allowed_banned_names_table') {

--- a/src/acore-wp-plugin/src/Components/CharactersMenu/CharactersController.php
+++ b/src/acore-wp-plugin/src/Components/CharactersMenu/CharactersController.php
@@ -14,10 +14,18 @@ class CharactersController {
 
     public function loadHome() {
         if ($_SERVER["REQUEST_METHOD"] == "POST") {
-            $this->saveCharacterOrder();
-            ?>
-            <div class="updated"><p><strong>Character settings succesfully saved.</strong></p></div>
-            <?php
+            check_admin_referer('acore_character_order', 'acore_character_order_nonce');
+            if (isset($_POST["acore_reset_order"])) {
+                $this->resetCharacterOrder();
+                ?>
+                <div class="updated"><p><strong>Character order reset successfully.</strong></p></div>
+                <?php
+            } else {
+                $this->saveCharacterOrder();
+                ?>
+                <div class="updated"><p><strong>Character settings succesfully saved.</strong></p></div>
+                <?php
+            }
         }
 
         $accId = ACoreServices::I()->getAcoreAccountId();
@@ -36,6 +44,16 @@ class CharactersController {
 
     public function getView() {
         return $this->view;
+    }
+
+    private function resetCharacterOrder() {
+        $accId = ACoreServices::I()->getAcoreAccountId();
+        $conn = ACoreServices::I()->getCharacterEm()->getConnection();
+        $stmt = $conn->prepare(
+            "UPDATE `characters` SET `order` = NULL WHERE `account` = ? AND `deleteDate` IS NULL"
+        );
+        $stmt->bindValue(1, $accId);
+        $stmt->executeQuery();
     }
 
     private function saveCharacterOrder() {

--- a/src/acore-wp-plugin/src/Components/CharactersMenu/CharactersView.php
+++ b/src/acore-wp-plugin/src/Components/CharactersMenu/CharactersView.php
@@ -2,6 +2,8 @@
 
 namespace ACore\Components\CharactersMenu;
 
+use ACore\Utils\AcoreCharColors;
+
 class CharactersView {
     private $controller;
 
@@ -16,44 +18,47 @@ class CharactersView {
     public function getHomeRender($characters) {
         ob_start();
         wp_enqueue_style('bootstrap-css', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css', array(), '5.1.3');
-        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.1');
+        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.5');
         wp_enqueue_script('bootstrap-js', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js', array(), '5.1.3');
         wp_enqueue_script('jquery-ui-sortable');
         ?>
         <div class="wrap">
-            <h2>Characters Settings</h2>
-            <p>Check some details and configure of your characters.</p>
-
             <div class="row">
                 <div class="col-sm-4">
                     <div class="card">
                         <div class="card-body">
-                            <h3>Order</h3>
-                            <p>Change the order in which the characters appear in your in-game character selection screen.</p>
+                            <h3>Order Character Screen</h3>
+                            <p>Change the order in which the characters appear in your in-game character selection screen, by dragging them, matches in-game position.</p>
                             <hr>
                             <form action="" method="POST" novalidate="novalidate">
+                                <?php wp_nonce_field('acore_character_order', 'acore_character_order_nonce'); ?>
 
-                                <ul id="acore-characters-order" class="list-unstyled">
-                                    <?php foreach ($characters as $char) { ?>
+                                <ul id="acore-characters-order" class="acore-char-list list-unstyled">
+                                    <?php $charPos = 0; foreach ($characters as $char) {
+                                        $clsStyle = AcoreCharColors::rowStyle(intval($char["class"]), intval($char["race"]));
+                                        $charPos++;
+                                        $displayPos = $char['order'] !== null ? intval($char['order']) + 1 : $charPos;
+                                    ?>
                                         <li>
-                                            <div class="menu-item-bar">
-                                                <div class="menu-item-handle ui-sortable-handle">
-                                                    <span class="item-title menu-item-title"><?= $char["name"] ?></span>
-                                                    <span class="item-controls">
-                                                    <span class="item-type">
-                                                        level <?= $char["level"] ?>&ensp;
-                                                        <img src="<?= ACORE_URL_PLG . "web/assets/race/" . $char["race"] . ($char["gender"] == 0 ? "m" : "f") . ".webp"; ?>">
-                                                        <img src="<?= ACORE_URL_PLG . "web/assets/class/" . $char["class"] . ".webp"; ?>">
-                                                    </span>
-                                                </div>
+                                            <div class="acore-char-row" style="<?= esc_attr($clsStyle) ?>">
+                                                <span class="acore-char-pos"><?= $displayPos ?></span>
+                                                <span class="acore-char-name"><?= esc_html($char["name"]) ?></span>
+                                                <span class="acore-char-meta">
+                                                    <span class="acore-level" data-exp="<?= AcoreCharColors::expansionSlug(intval($char["level"])) ?>" title="<?= esc_attr(AcoreCharColors::expansionLabel(intval($char["level"]))) ?>">Level <?= intval($char["level"]) ?></span>
+                                                    <img class="race-icon" height="32" width="32" title="<?= esc_attr(AcoreCharColors::getRaceName(intval($char["race"]))) ?>" src="<?= esc_url(ACORE_URL_PLG . "web/assets/race/" . intval($char["race"]) . (intval($char["gender"]) == 0 ? "m" : "f") . ".webp") ?>">
+                                                    <img class="class-icon" height="32" width="32" title="<?= esc_attr(AcoreCharColors::getClassName(intval($char["class"]))) ?>" src="<?= esc_url(ACORE_URL_PLG . "web/assets/class/" . intval($char["class"]) . ".webp") ?>">
+                                                </span>
                                             </div>
-                                            <input name="characterorder[]" value="<?= $char["guid"] ?>">
+                                            <input type="hidden" name="characterorder[]" value="<?= esc_attr($char["guid"]) ?>">
                                         </li>
                                     <?php } ?>
                                 </ul>
 
                                 <?php if (!empty($characters)) { ?>
-                                    <input type="submit" name="submit" class="button button-primary" value="Save Order">
+                                    <div style="display:flex; justify-content:space-between; align-items:center; margin-top:8px;">
+                                        <input type="submit" name="submit" class="button button-primary" value="Save Order">
+                                        <input type="submit" name="acore_reset_order" class="button acore-btn-danger" value="Reset Order">
+                                    </div>
                                 <?php } ?>
                             </form>
                         </div>
@@ -62,12 +67,23 @@ class CharactersView {
             </div>
         </div>
 
-        <script type="text/javascript">
-            jQuery(document).ready(function($) {
-                $("#acore-characters-order").sortable();
-            });
-        </script>
+        <!-- .acore-btn-danger styling lives in theme.css (shared light/dark) -->
 
+        <script>
+        jQuery(document).ready(function($) {
+            $("#acore-characters-order").sortable({
+                update: function(event, ui) {
+                    var order = [];
+                    $("#acore-characters-order li").each(function(index) {
+                        var input = $(this).find("input[name='characterorder[]']");
+                        order.push(input.val());
+                        $(this).find(".acore-char-pos").text(index + 1);
+                    });
+                }
+            });
+            $("#acore-characters-order").disableSelection();
+        });
+        </script>
         <?php
         return ob_get_clean();
     }

--- a/src/acore-wp-plugin/src/Components/MailReturnMenu/MailReturnController.php
+++ b/src/acore-wp-plugin/src/Components/MailReturnMenu/MailReturnController.php
@@ -64,7 +64,7 @@ class MailReturnController
 
         // Get mails sent by this character that are unread by the receiver
         // messageType = 0 means player mail
-        $query = "SELECT m.`id`, m.`subject`, m.`has_items`, m.`money`,
+        $query = "SELECT m.`id`, m.`subject`, m.`has_items`, m.`money`, m.`cod`,
                 m.`expire_time`, m.`deliver_time`,
                 rc.`name` AS receiver_name, rc.`race` AS receiver_race,
                 rc.`class` AS receiver_class, rc.`gender` AS receiver_gender,
@@ -94,7 +94,7 @@ class MailReturnController
             $placeholders = implode(',', array_fill(0, count($mailIds), '?'));
             $worldDb = Opts::I()->acore_db_world_name;
             $itemQuery = "SELECT mi.`mail_id`, ii.`itemEntry`, ii.`count`,
-                    it.`name` AS item_name
+                    it.`name` AS item_name, it.`Quality` AS item_quality
                 FROM `mail_items` mi
                 JOIN `item_instance` ii ON mi.`item_guid` = ii.`guid`
                 JOIN `$worldDb`.`item_template` it ON ii.`itemEntry` = it.`entry`

--- a/src/acore-wp-plugin/src/Components/MailReturnMenu/MailReturnView.php
+++ b/src/acore-wp-plugin/src/Components/MailReturnMenu/MailReturnView.php
@@ -2,6 +2,8 @@
 
 namespace ACore\Components\MailReturnMenu;
 
+use ACore\Utils\AcoreCharColors;
+
 
 class MailReturnView
 {
@@ -17,58 +19,80 @@ class MailReturnView
         ob_start();
 
         wp_enqueue_style('bootstrap-css', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css', array(), '5.1.3');
-        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.1');
+        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.5');
         wp_enqueue_script('bootstrap-js', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js', array(), '5.1.3');
         wp_enqueue_script('jquery');
-        wp_enqueue_script('acore-mail-return-js', ACORE_URL_PLG . 'web/assets/mail-return/mail-return.js', array('jquery'), null, true);
+        wp_enqueue_script('power-js', 'https://wow.zamimg.com/widgets/power.js', array(), null, false);
+        wp_enqueue_script('acore-mail-return-js', ACORE_URL_PLG . 'web/assets/mail-return/mail-return.js', array('jquery'), '2.3', true);
+        wp_localize_script('acore-mail-return-js', 'mailReturnData', [
+            'mailsUrl'  => rest_url(ACORE_SLUG . '/v1/mail-return/list'),
+            'returnUrl' => rest_url(ACORE_SLUG . '/v1/mail-return'),
+            'assetsUrl' => ACORE_URL_PLG . 'web/assets/',
+            'nonce'     => wp_create_nonce('wp_rest'),
+        ]);
 
 ?>
 
-        <div class="wrap">
-            <div class="col-sm-6">
-                <div class="card">
-                    <div class="card-body">
-                        <h3>Mail Return</h3>
-                        <p>You can return sent mails that have not yet been read by the recipient in this page. Select the character, the sent mail and hit return.</p>
-                        <hr>
+        <script>const whTooltips = {colorLinks: true, iconizeLinks: true, renameLinks: true};</script>
+        <div class="wrap" id="acore-mail-return-page">
+            <div id="mail-return-layout">
 
-                        <label for="mail-return-char-select"><strong>Select Character:</strong></label>
-                        <select id="mail-return-char-select" class="form-select mb-3">
-                            <option value="">-- Select a character --</option>
-                            <?php foreach ($chars as $char) { ?>
-                                <option value="<?= intval($char["guid"]) ?>" data-name="<?= esc_attr($char["name"]) ?>">
-                                    <?= esc_html($char["name"]) ?> (Level <?= intval($char["level"]) ?>)
-                                </option>
-                            <?php } ?>
-                        </select>
+                <!-- Col 1: character selector - always visible, same width -->
+                <div id="mail-return-sidebar">
+                    <div class="card">
+                        <div class="card-body">
+                            <h3>Mail Return</h3>
+                            <p>You can return sent mails that have not yet been read by the recipient in this page. Select the character, the sent mail and hit return.</p>
+                            <hr>
 
-                        <div id="mail-return-loading" style="display:none;" class="text-center my-3">
-                            <div class="spinner-border text-primary" role="status">
-                                <span class="visually-hidden">Loading...</span>
+                            <strong>Select Character:</strong>
+                            <ul id="acore-characters-mail" class="acore-char-list list-unstyled mt-2">
+                                <?php foreach ($chars as $char) {
+                                    $clsStyle = AcoreCharColors::rowStyle(intval($char['class']), intval($char['race']));
+                                ?>
+                                    <li>
+                                        <button type="button" class="acore-char-row acore-char-card" data-char-guid="<?= intval($char['guid']) ?>" style="<?= esc_attr($clsStyle) ?>">
+                                            <span class="acore-char-name"><?= esc_html($char['name']) ?></span>
+                                            <span class="acore-char-meta">
+                                                <span class="acore-level" data-exp="<?= AcoreCharColors::expansionSlug(intval($char['level'])) ?>" title="<?= esc_attr(AcoreCharColors::expansionLabel(intval($char['level']))) ?>">Level <?= intval($char['level']) ?></span>
+                                                <img class="race-icon" height="32" width="32" alt="<?= esc_attr(AcoreCharColors::getRaceName(intval($char['race']))) ?>" title="<?= esc_attr(AcoreCharColors::getRaceName(intval($char['race']))) ?>" src="<?= ACORE_URL_PLG . 'web/assets/race/' . intval($char['race']) . (intval($char['gender']) == 0 ? 'm' : 'f') . '.webp' ?>">
+                                                <img class="class-icon" height="32" width="32" alt="<?= esc_attr(AcoreCharColors::getClassName(intval($char['class']))) ?>" title="<?= esc_attr(AcoreCharColors::getClassName(intval($char['class']))) ?>" src="<?= ACORE_URL_PLG . 'web/assets/class/' . intval($char['class']) . '.webp' ?>">
+                                            </span>
+                                        </button>
+                                    </li>
+                                <?php } ?>
+                            </ul>
+
+                            <div id="mail-return-loading" style="display:none;" class="text-center my-3">
+                                <div class="spinner-border text-primary" role="status">
+                                    <span class="visually-hidden">Loading...</span>
+                                </div>
+                            </div>
+
+                            <!-- Empty state lives inside the card -->
+                            <div id="mail-return-empty-wrap" style="display:none;">
+                                <hr>
+                                <h5>Unread Sent Mails</h5>
+                                <p id="mail-return-empty" class="text-muted">No unread sent mails found for this character.</p>
                             </div>
                         </div>
+                    </div>
+                </div><!-- /mail-return-sidebar -->
 
-                        <div id="mail-return-list" style="display:none;">
-                            <h5>Unread Sent Mails</h5>
-                            <ul id="mail-return-items" class="list-unstyled"></ul>
-                            <p id="mail-return-empty" style="display:none;" class="text-muted">No unread sent mails found for this character.</p>
+                <!-- Cols 2-3: mail list - hidden until mails are loaded by JS -->
+                <div id="mail-return-content">
+                    <div class="card">
+                        <div class="card-body">
+                            <h5 id="mail-return-heading">Unread Sent Mails</h5>
+                            <ul id="mail-return-items" class="list-unstyled mb-0"></ul>
                         </div>
                     </div>
-                </div>
-            </div>
-        </div>
+                </div><!-- /mail-return-content -->
 
-        <script>
-            var mailReturnData = {
-                nonce: "<?php echo esc_js(wp_create_nonce('wp_rest')); ?>",
-                mailsUrl: "<?php echo esc_url(get_rest_url(null, ACORE_SLUG . '/v1/mail-return/list')); ?>",
-                returnUrl: "<?php echo esc_url(get_rest_url(null, ACORE_SLUG . '/v1/mail-return')); ?>",
-                assetsUrl: "<?php echo esc_url(ACORE_URL_PLG . 'web/assets/'); ?>"
-            };
-        </script>
-        <script>var whTooltips = {colorLinks: true, iconizeLinks: true, renameLinks: true};</script>
-        <script src="https://wow.zamimg.com/js/tooltips.js"></script>
-<?php
+            </div><!-- /mail-return-layout -->
+        </div><!-- /wrap -->
+
+        <?php
         return ob_get_clean();
     }
 }

--- a/src/acore-wp-plugin/src/Components/ResurrectionScrollMenu/ResurrectionScrollMenu.php
+++ b/src/acore-wp-plugin/src/Components/ResurrectionScrollMenu/ResurrectionScrollMenu.php
@@ -24,9 +24,19 @@ class ResurrectionScrollMenu
         return self::$instance;
     }
 
+    private function isAvailable(): bool
+    {
+        if (Opts::I()->acore_resurrection_scroll != '1') {
+            return false;
+        }
+        $csv      = get_option('acore_modules_csv', '');
+        $modules  = $csv ? array_map('trim', explode(',', $csv)) : [];
+        return in_array('mod-resurrection-scroll', $modules);
+    }
+
     function acore_resurrection_scroll_menu()
     {
-        if (Opts::I()->acore_resurrection_scroll == '1') {
+        if ($this->isAvailable()) {
             add_submenu_page('profile.php', 'Scroll of Resurrection', 'Scroll of Resurrection', 'read', ACORE_SLUG . '-resurrection-scroll', array($this, 'acore_resurrection_scroll_menu_page'));
         }
     }
@@ -41,6 +51,5 @@ class ResurrectionScrollMenu
 function resurrection_scroll_menu_init()
 {
     $menu = ResurrectionScrollMenu::I();
-
     add_action('admin_menu', array($menu, 'acore_resurrection_scroll_menu'));
 }

--- a/src/acore-wp-plugin/src/Components/ResurrectionScrollMenu/ResurrectionScrollView.php
+++ b/src/acore-wp-plugin/src/Components/ResurrectionScrollMenu/ResurrectionScrollView.php
@@ -16,7 +16,7 @@ class ResurrectionScrollView
         ob_start();
 
         wp_enqueue_style('bootstrap-css', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css', array(), '5.1.3');
-        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.1');
+        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.5');
         wp_enqueue_script('bootstrap-js', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js', array(), '5.1.3');
 
         // Determine account status
@@ -42,7 +42,7 @@ class ResurrectionScrollView
 
 ?>
 
-        <div class="wrap">
+        <div class="wrap acore-rscroll">
             <h2>Scroll of Resurrection</h2>
 
             <div class="row">
@@ -66,10 +66,10 @@ class ResurrectionScrollView
                                                 <?php if ($isActive) { ?>
                                                     <span class="badge bg-success">Enrolled</span>
                                                 <?php } elseif ($isEligible) { ?>
-                                                    <span class="badge bg-info">Eligible</span>
+                                                    <span class="badge bg-success">Eligible</span>
                                                     <span class="text-muted">- Log in to the game server to activate</span>
                                                 <?php } else { ?>
-                                                    <span class="badge bg-secondary">Not Eligible</span>
+                                                    <span class="badge bg-danger">Not Eligible</span>
                                                     <?php if ($lastLogout) {
                                                         $eligibleTimestamp = $lastLogout + ($daysInactive * 86400);
                                                         $eligibleDate = new \DateTime();

--- a/src/acore-wp-plugin/src/Components/ServerInfo/ServerInfoApi.php
+++ b/src/acore-wp-plugin/src/Components/ServerInfo/ServerInfoApi.php
@@ -15,12 +15,601 @@ class ServerInfoApi {
 }
 
 
+/**
+ * Pure-PHP TOTP validator (RFC 6238 / HOTP-SHA1).
+ * Accepts the Base32-encoded secret stored by WP2FA and a 6-digit token string.
+ * Validates against the current 30-second window +-1 step.
+ */
+function acore_totp_validate(string $base32Secret, string $rawToken): bool {
+    $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+    $input    = strtoupper(rtrim($base32Secret, '='));
+    $bits     = '';
+    foreach (str_split($input) as $char) {
+        $pos = strpos($alphabet, $char);
+        if ($pos === false) continue;
+        $bits .= str_pad(decbin($pos), 5, '0', STR_PAD_LEFT);
+    }
+    $secret = '';
+    foreach (str_split($bits, 8) as $chunk) {
+        if (strlen($chunk) < 8) break;
+        $secret .= chr(bindec($chunk));
+    }
+    if ($secret === '') return false;
+
+    $token     = (int) $rawToken;
+    $timestamp = (int) floor(time() / 30);
+
+    for ($step = -1; $step <= 1; $step++) {
+        $t    = $timestamp + $step;
+        $msg  = "\x00\x00\x00\x00" . pack('N', $t);
+        $hash = hash_hmac('sha1', $msg, $secret, true);
+        $off  = ord($hash[19]) & 0x0f;
+        $otp  = (
+            ((ord($hash[$off])   & 0x7f) << 24) |
+            ((ord($hash[$off+1]) & 0xff) << 16) |
+            ((ord($hash[$off+2]) & 0xff) <<  8) |
+             (ord($hash[$off+3]) & 0xff)
+        );
+        if (($otp % 1000000) === $token) return true;
+    }
+    return false;
+}
+
+/**
+ * Validate a 6-digit website 2FA (TOTP) code for a user.
+ *
+ * Uses the WP 2FA plugin's own authenticator
+ * (\WP2FA\Authenticator\Authentication::is_valid_authcode), which transparently
+ * handles the plugin's "lsc_" key prefix, OpenSSL decryption and the configured
+ * time-drift window. Falls back to a manual decrypt + RFC 6238 check for older
+ * plugin builds that lack that method.
+ */
+function acore_wp2fa_code_is_valid(int $userId, string $token): bool {
+    $rawKey = (string) get_user_meta($userId, 'wp_2fa_totp_key', true);
+    if ($rawKey === '') return false;
+
+    // Preferred path: let the plugin validate the code itself.
+    $auth = '\WP2FA\Authenticator\Authentication';
+    if (is_callable([$auth, 'is_valid_authcode'])) {
+        if (is_callable([$auth, 'clear_decrypted_key'])) {
+            $auth::clear_decrypted_key();
+        }
+        try {
+            return (bool) $auth::is_valid_authcode($rawKey, $token);
+        } catch (\Throwable $e) {
+            // fall through to the manual path below
+        }
+    }
+
+    // Fallback: decrypt the secret ourselves, then validate (RFC 6238).
+    $secret = acore_wp2fa_decrypt_secret($rawKey);
+    if ($secret === '') return false;
+    return acore_totp_validate($secret, $token);
+}
+
+/**
+ * Decrypt a WP 2FA stored TOTP key into its raw Base32 secret.
+ * The plugin stores the value as "lsc_" + base64(iv . ciphertext) when OpenSSL is
+ * available, or as a plain Base32 secret otherwise.
+ */
+function acore_wp2fa_decrypt_secret(string $rawKey): string {
+    if ($rawKey === '') return '';
+
+    $prefix     = 'lsc_';
+    $hasPrefix  = strpos($rawKey, $prefix) === 0;
+    $cipherText = $hasPrefix ? substr($rawKey, strlen($prefix)) : $rawKey;
+
+    // No prefix and already Base32? Encryption was disabled - use as-is.
+    if (!$hasPrefix) {
+        $clean = strtoupper(rtrim(trim($cipherText), '='));
+        if ($clean !== '' && preg_match('/^[A-Z2-7]+$/', $clean)) {
+            return $cipherText;
+        }
+    }
+
+    foreach (['\WP2FA\Authenticator\Open_SSL', '\WP2FA\Utils\Open_SSL'] as $cls) {
+        if (is_callable([$cls, 'decrypt'])) {
+            try { $dec = $cls::decrypt($cipherText); }
+            catch (\Throwable $e) { $dec = ''; }
+            if (is_string($dec) && $dec !== '') return $dec;
+        }
+    }
+
+    return '';
+}
+
+/**
+ * Whether the user currently has Website 2FA (TOTP) active.
+ */
+function acore_website_totp_enabled(int $userId): bool {
+    $primary = get_user_meta($userId, 'wp_2fa_enabled_methods', true);
+    $totpKey = get_user_meta($userId, 'wp_2fa_totp_key', true);
+    return !empty($totpKey) && (
+        (is_array($primary) && in_array('totp', $primary, true)) ||
+        $primary === 'totp'
+    );
+}
+
+function acore_website_2fa_enabled(int $userId): bool {
+    $primary = get_user_meta($userId, 'wp_2fa_enabled_methods', true);
+    $methods = is_array($primary) ? $primary : ($primary !== '' ? [$primary] : []);
+    return acore_website_totp_enabled($userId) || in_array('email', $methods, true);
+}
+
+function acore_2fa_unlock_key(int $userId): string {
+    $token = function_exists('wp_get_session_token') ? (string) wp_get_session_token() : '';
+    return 'acore_2fa_panel_unlock_' . $userId . '_' . hash('sha256', $token);
+}
+
+function acore_2fa_attempt_key(int $userId): string {
+    $token = function_exists('wp_get_session_token') ? (string) wp_get_session_token() : '';
+    return 'acore_2fa_verify_attempts_' . $userId . '_' . hash('sha256', $token);
+}
+
+/**
+ * Whether the current user has In-game 2FA active (account.totp_secret set).
+ */
+function acore_ingame_2fa_enabled(int $userId): bool {
+    try {
+        $services = \ACore\Manager\ACoreServices::I();
+        $accId    = $services->getAcoreAccountId();
+        if (!$accId) return false;
+        $conn = $services->getAccountEm()->getConnection();
+        $row  = $conn->executeQuery('SELECT totp_secret FROM account WHERE id = ?', [$accId])->fetchAssociative();
+        return $row && $row['totp_secret'] !== null;
+    } catch (\Throwable $e) {
+        return false;
+    }
+}
+
+/**
+ * Detect a user-initiated Website 2FA removal (done through the WP 2FA plugin UI)
+ * and log it with the user's IP. Admin removals pre-set the "last seen" flag to
+ * '0', so they are never misattributed here. Runs in the user's own session, so
+ * the only IP ever recorded is the user's - never an administrator's.
+ */
+function acore_2fa_sync_self_removals(int $userId): void {
+    $enabled = acore_website_2fa_enabled($userId);
+    $seen    = get_user_meta($userId, 'acore_2fa_ws_seen_enabled', true);
+
+    if ($seen === '') {
+        update_user_meta($userId, 'acore_2fa_ws_seen_enabled', $enabled ? '1' : '0');
+        return;
+    }
+
+    if ($seen === '1' && !$enabled) {
+        $log = get_user_meta($userId, 'acore_2fa_admin_log', true);
+        $log = is_array($log) ? $log : [];
+        $log[] = [
+            'type'      => 'website',
+            'by'        => 'self',
+            'timestamp' => time(),
+            'ip'        => \ACore\Hooks\User\acore_resolve_client_ip(),
+        ];
+        update_user_meta($userId, 'acore_2fa_admin_log', $log);
+    }
+
+    update_user_meta($userId, 'acore_2fa_ws_seen_enabled', $enabled ? '1' : '0');
+}
+
 add_action( 'rest_api_init', function () {
    register_rest_route( ACORE_SLUG . '/v1', 'server-info', array(
        'methods'  => 'GET',
+       'permission_callback' => function() { return current_user_can('manage_options'); },
        'callback' => function( $request ) {
-            $data = ['message' => ServerInfoApi::serverInfo()];
-            return $data;
+            $result = ServerInfoApi::serverInfo();
+            $errorPatterns = [
+                'could not connect', 'connection refused', 'operation timed out',
+                'error fetching', 'failed to enable', 'soap fault', 'not configured',
+                'unable to connect', 'network unreachable',
+            ];
+            foreach ($errorPatterns as $pattern) {
+                if (stripos($result, $pattern) !== false) {
+                    error_log('[acore] server-info SOAP error: ' . (is_scalar($result) ? (string) $result : 'non-scalar response'));
+                    return new \WP_Error('soap_error', __('Server information is temporarily unavailable.', 'acore-wp-plugin'), ['status' => 503]);
+                }
+            }
+            return ['message' => $result];
+       }
+   ) );
+
+   $defaultRequirements = [['Scroll of Resurrection', 'mod-resurrection-scroll']];
+
+   register_rest_route( ACORE_SLUG . '/v1', 'server-module-requirements', array(
+       'methods'             => 'GET',
+       'permission_callback' => function() { return current_user_can('manage_options'); },
+       'callback'            => function( $request ) use ($defaultRequirements) {
+           return ['requirements' => get_option('acore_module_requirements', $defaultRequirements)];
+       }
+   ));
+
+   register_rest_route( ACORE_SLUG . '/v1', 'server-module-requirements', array(
+       'methods'             => 'POST',
+       'permission_callback' => function() { return current_user_can('manage_options'); },
+       'callback'            => function( $request ) {
+           $data  = $request->get_json_params();
+           $reqs  = isset($data['requirements']) ? $data['requirements'] : [];
+           $clean = [];
+           foreach ($reqs as $row) {
+               if (is_array($row) && count($row) === 2) {
+                   $clean[] = [sanitize_text_field($row[0]), sanitize_text_field($row[1])];
+               }
+           }
+           update_option('acore_module_requirements', $clean);
+           return ['success' => true, 'requirements' => $clean];
+       }
+   ));
+
+   register_rest_route( ACORE_SLUG . '/v1', 'server-modules', array(
+       'methods'             => 'POST',
+       'permission_callback' => function() { return current_user_can('manage_options'); },
+       'callback'            => function( $request ) {
+           try {
+               $raw = ACoreServices::I()->getServerSoap()->executeCommand('.server debug');
+           } catch (\Throwable $e) {
+               return new \WP_Error('soap_error', $e->getMessage(), ['status' => 503]);
+           }
+           if (!is_string($raw)) {
+               return new \WP_Error('soap_error', __('Unexpected module response from the server.', 'acore-wp-plugin'), ['status' => 503]);
+           }
+           $modules  = [];
+           $capturing = false;
+           foreach (explode("\n", $raw) as $line) {
+               $line = trim($line);
+               if (!$capturing) {
+                   if (stripos($line, 'List of enabled modules:') !== false) $capturing = true;
+                   continue;
+               }
+               if (preg_match('/\b(mod-[a-zA-Z0-9_-]+)/', $line, $m)) $modules[] = $m[1];
+           }
+           $csv       = implode(',', $modules);
+           $timestamp = time();
+           update_option('acore_modules_csv',       $csv);
+           update_option('acore_modules_refreshed', $timestamp);
+           return ['modules' => $modules, 'csv' => $csv, 'refreshed' => $timestamp];
+       }
+   ) );
+
+   // Admin: check 2FA status for any user
+   register_rest_route( ACORE_SLUG . '/v1', 'admin/2fa-check', array(
+       'methods'             => 'POST',
+       'permission_callback' => function() { return current_user_can('manage_options'); },
+       'callback'            => function( \WP_REST_Request $request ) {
+           $data     = $request->get_json_params();
+           $type     = isset($data['type'])     ? sanitize_text_field($data['type'])     : '';
+           $username = isset($data['username']) ? sanitize_text_field($data['username']) : '';
+           if (!in_array($type, ['website', 'ingame'], true))
+               return new \WP_Error('invalid_type', 'Invalid type.', ['status' => 400]);
+           if ($username === '')
+               return new \WP_Error('missing_username', 'Username is required.', ['status' => 400]);
+           $user = get_user_by('login', $username);
+           if (!$user)
+               return new \WP_Error('user_not_found', 'No WordPress account found with that username.', ['status' => 404]);
+
+           $log         = get_user_meta($user->ID, 'acore_2fa_admin_log', true);
+           $log         = is_array($log) ? $log : [];
+           $lastRemoval = null;
+           foreach (array_reverse($log) as $entry) {
+               if ($entry['type'] === $type) { $lastRemoval = $entry; break; }
+           }
+
+           if ($type === 'website') {
+               $active      = acore_website_2fa_enabled($user->ID);
+               $backupCodes = get_user_meta($user->ID, 'wp_2fa_backup_codes', true);
+               $resp = [
+                   'found'        => true,
+                   'username'     => $user->user_login,
+                   'active'       => $active,
+                   'backup_codes' => is_array($backupCodes) ? count($backupCodes) : 0,
+               ];
+               if ($lastRemoval) $resp['last_removal'] = ['date' => wp_date('jS \o\f F, Y \a\t H:i', $lastRemoval['timestamp']), 'by' => $lastRemoval['by'] ?? 'admin', 'staff' => $lastRemoval['staff'] ?? null, 'ip' => $lastRemoval['ip'] ?? null];
+               return $resp;
+           }
+
+           try {
+               $conn   = ACoreServices::I()->getAccountEm()->getConnection();
+               $result = $conn->executeQuery('SELECT totp_secret FROM account WHERE username = ?', [strtoupper($username)]);
+               $row    = $result->fetchAssociative();
+               if (!$row) return new \WP_Error('no_game_account', 'No game account found for this user.', ['status' => 404]);
+               $resp = ['found' => true, 'username' => $user->user_login, 'active' => $row['totp_secret'] !== null];
+               if ($lastRemoval) $resp['last_removal'] = ['date' => wp_date('jS \o\f F, Y \a\t H:i', $lastRemoval['timestamp']), 'by' => $lastRemoval['by'] ?? 'admin', 'staff' => $lastRemoval['staff'] ?? null, 'ip' => $lastRemoval['ip'] ?? null];
+               return $resp;
+           } catch (\Exception $e) {
+               return new \WP_Error('db_error', 'Database error.', ['status' => 500]);
+           }
+       }
+   ));
+
+   // Admin: remove 2FA for any user and log the action
+   register_rest_route( ACORE_SLUG . '/v1', 'admin/2fa-remove', array(
+       'methods'             => 'POST',
+       'permission_callback' => function() { return current_user_can('manage_options'); },
+       'callback'            => function( \WP_REST_Request $request ) {
+           $data     = $request->get_json_params();
+           $type     = isset($data['type'])     ? sanitize_text_field($data['type'])     : '';
+           $username = isset($data['username']) ? sanitize_text_field($data['username']) : '';
+           if (!in_array($type, ['website', 'ingame'], true))
+               return new \WP_Error('invalid_type', 'Invalid type.', ['status' => 400]);
+           if ($username === '')
+               return new \WP_Error('missing_username', 'Username is required.', ['status' => 400]);
+           $user = get_user_by('login', $username);
+           if (!$user)
+               return new \WP_Error('user_not_found', 'No WordPress account found with that username.', ['status' => 404]);
+
+           if ($type === 'website') {
+               delete_user_meta($user->ID, 'wp_2fa_totp_key');
+               delete_user_meta($user->ID, 'wp_2fa_enabled_methods');
+               delete_user_meta($user->ID, 'wp_2fa_backup_methods_enabled');
+               delete_user_meta($user->ID, 'wp_2fa_grace_period_expiry');
+               delete_user_meta($user->ID, 'wp_2fa_user_setup_started_at');
+               delete_user_meta($user->ID, 'wp_2fa_user_authenticated_methods');
+               // Pre-set the user's last-seen flag so the self-removal detector
+               // does not misattribute this admin action to the user.
+               update_user_meta($user->ID, 'acore_2fa_ws_seen_enabled', '0');
+           } else {
+               try {
+                   $conn = ACoreServices::I()->getAccountEm()->getConnection();
+                   $rows = $conn->executeStatement('UPDATE account SET totp_secret = NULL WHERE username = ?', [strtoupper($username)]);
+                   if ($rows === 0) return new \WP_Error('no_game_account', 'No game account found for this user.', ['status' => 404]);
+               } catch (\Exception $e) {
+                   return new \WP_Error('db_error', 'Database error.', ['status' => 500]);
+               }
+           }
+
+           $staff = wp_get_current_user();
+           $now   = time();
+           $log   = get_user_meta($user->ID, 'acore_2fa_admin_log', true);
+           $log   = is_array($log) ? $log : [];
+           $log[] = ['type' => $type, 'by' => 'admin', 'timestamp' => $now, 'staff' => $staff->user_login, 'staff_id' => $staff->ID];
+           update_user_meta($user->ID, 'acore_2fa_admin_log', $log);
+           return ['success' => true, 'date' => wp_date('jS \o\f F, Y \a\t H:i', $now), 'staff' => $staff->user_login];
+       }
+   ));
+
+   // Admin: remove a user's WP 2FA backup codes and notify them
+   register_rest_route( ACORE_SLUG . '/v1', 'admin/backup-codes-remove', array(
+       'methods'             => 'POST',
+       'permission_callback' => function() { return current_user_can('manage_options'); },
+       'callback'            => function( \WP_REST_Request $request ) {
+           $data     = $request->get_json_params();
+           $username = isset($data['username']) ? sanitize_text_field($data['username']) : '';
+           if ($username === '')
+               return new \WP_Error('missing_username', 'Username is required.', ['status' => 400]);
+           $user = get_user_by('login', $username);
+           if (!$user)
+               return new \WP_Error('user_not_found', 'No WordPress account found with that username.', ['status' => 404]);
+
+           delete_user_meta($user->ID, 'wp_2fa_backup_codes');
+
+           $staff = wp_get_current_user();
+           $now   = time();
+           $log   = get_user_meta($user->ID, 'acore_2fa_admin_log', true);
+           $log   = is_array($log) ? $log : [];
+           $log[] = ['type' => 'backup', 'by' => 'admin', 'timestamp' => $now, 'staff' => $staff->user_login, 'staff_id' => $staff->ID];
+           update_user_meta($user->ID, 'acore_2fa_admin_log', $log);
+
+           return ['success' => true, 'date' => wp_date('jS \o\f F, Y \a\t H:i', $now), 'staff' => $staff->user_login];
+       }
+   ));
+
+   // Admin: look up a user's recorded login IP history (same data the user sees)
+   register_rest_route( ACORE_SLUG . '/v1', 'admin/login-history', array(
+       'methods'             => 'POST',
+       'permission_callback' => function() { return current_user_can('manage_options'); },
+       'callback'            => function( \WP_REST_Request $request ) {
+           $data     = $request->get_json_params();
+           $username = isset($data['username']) ? sanitize_text_field($data['username']) : '';
+           $page     = max(1, (int) ($data['page'] ?? 1));
+           $perPage  = 50;
+           if ($username === '')
+               return new \WP_Error('missing_username', 'Username is required.', ['status' => 400]);
+
+           $user = get_user_by('login', $username);
+           if (!$user)
+               return new \WP_Error('user_not_found', 'No WordPress account found with that username.', ['status' => 404]);
+           $all = \ACore\Hooks\User\acore_get_login_history($user->ID, 500);
+
+           $all    = is_array($all) ? $all : [];
+           $total  = count($all);
+           $offset = ($page - 1) * $perPage;
+           $slice  = array_slice($all, $offset, $perPage);
+
+           $history = [];
+           foreach ($slice as $r) {
+               $history[] = [
+                   'ip'      => $r['ip_address'] ?? '',
+                   'country' => $r['country'] ?? 'Unknown',
+                   'date'    => isset($r['login_at']) ? \ACore\Hooks\User\acore_format_connection_date($r['login_at']) : '',
+                   'where'   => (($r['source'] ?? 'website') === 'ingame') ? 'In-game' : 'Website',
+               ];
+           }
+           return [
+               'found'    => true,
+               'username' => $username,
+               'history'  => $history,
+               'total'    => $total,
+               'from'     => $total ? $offset + 1 : 0,
+               'to'       => $offset + count($slice),
+               'page'     => $page,
+               'has_more' => ($offset + count($slice)) < $total,
+           ];
+       }
+   ));
+
+   register_rest_route( ACORE_SLUG . '/v1', 'remove-ingame-2fa', array(
+       'methods'             => 'POST',
+       'permission_callback' => function() { return is_user_logged_in(); },
+       'callback'            => function( \WP_REST_Request $request ) {
+           $user = wp_get_current_user();
+           if (!acore_website_2fa_enabled($user->ID))
+               return new \WP_Error('no_website_2fa', __('You must have website 2FA enabled to remove in-game 2FA from here.'), ['status' => 403]);
+
+           // Authorise via a recent panel unlock (TOTP or email) OR a fresh TOTP code.
+           if (!get_transient(acore_2fa_unlock_key($user->ID))) {
+               if (!acore_website_totp_enabled($user->ID))
+                   return new \WP_Error('verify_required', __('Please verify your 2FA above before removing in-game 2FA.'), ['status' => 403]);
+               $data  = $request->get_json_params();
+               $token = isset($data['token']) ? trim((string) $data['token']) : '';
+               if (!preg_match('/^\d{6}$/', $token))
+                   return new \WP_Error('invalid_token', __('Please enter a valid 6-digit code.'), ['status' => 400]);
+               if (!\ACore\Components\ServerInfo\acore_wp2fa_code_is_valid($user->ID, $token))
+                   return new \WP_Error('wrong_token', __('Incorrect code. Please try again.'), ['status' => 401]);
+           }
+
+           try {
+               $accId = ACoreServices::I()->getAcoreAccountId();
+               if (!$accId) return new \WP_Error('no_account', __('Could not find your game account.'), ['status' => 404]);
+               $conn = ACoreServices::I()->getAccountEm()->getConnection();
+               $conn->executeStatement('UPDATE account SET totp_secret = NULL WHERE id = ?', [$accId]);
+               return ['success' => true];
+           } catch (\Exception $e) {
+               return new \WP_Error('db_error', __('Database error. Please try again.'), ['status' => 500]);
+           }
+       }
+   ) );
+
+   // User: verify own website 2FA (TOTP) code - used to gate sensitive panels (e.g. backup codes)
+   register_rest_route( ACORE_SLUG . '/v1', 'verify-website-2fa', array(
+       'methods'             => 'POST',
+       'permission_callback' => function() { return is_user_logged_in(); },
+       'callback'            => function( \WP_REST_Request $request ) {
+           $user   = wp_get_current_user();
+           if (!acore_website_totp_enabled($user->ID))
+               return new \WP_Error('no_website_2fa', __('Website 2FA is not enabled on your account.'), ['status' => 400]);
+
+           $attemptKey = acore_2fa_attempt_key($user->ID);
+           if ((int) get_transient($attemptKey) >= 5)
+               return new \WP_Error('rate_limited', __('Too many incorrect codes. Please wait a few minutes.', 'acore-wp-plugin'), ['status' => 429]);
+
+           $data  = $request->get_json_params();
+           $token = isset($data['token']) ? trim((string) $data['token']) : '';
+           if (!preg_match('/^\d{6}$/', $token))
+               return new \WP_Error('invalid_token', __('Please enter a valid 6-digit code.'), ['status' => 400]);
+           if (!\ACore\Components\ServerInfo\acore_wp2fa_code_is_valid($user->ID, $token)) {
+               set_transient($attemptKey, ((int) get_transient($attemptKey)) + 1, 10 * MINUTE_IN_SECONDS);
+               return new \WP_Error('wrong_token', __('Incorrect code. Please try again.'), ['status' => 401]);
+           }
+
+           delete_transient($attemptKey);
+           // Remember this unlock briefly so page refreshes don't re-prompt for the code.
+           set_transient(acore_2fa_unlock_key($user->ID), time(), 30 * MINUTE_IN_SECONDS);
+
+           return ['success' => true];
+       }
+   ) );
+
+   // User: email an unlock code (for accounts using email-based website 2FA)
+   register_rest_route( ACORE_SLUG . '/v1', 'request-email-2fa', array(
+       'methods'             => 'POST',
+       'permission_callback' => function() { return is_user_logged_in(); },
+       'callback'            => function() {
+           $user     = wp_get_current_user();
+           $rateKey  = 'acore_2fa_email_rate_' . $user->ID;
+           if (get_transient($rateKey))
+               return new \WP_Error('rate_limited', __('Please wait before requesting another code.'), ['status' => 429]);
+
+           $primary = get_user_meta($user->ID, 'wp_2fa_enabled_methods', true);
+           $methods = is_array($primary) ? $primary : ($primary !== '' ? [$primary] : []);
+           if (!in_array('email', $methods, true))
+               return new \WP_Error('no_email_2fa', __('Email 2FA is not enabled on your account.'), ['status' => 400]);
+
+           $code = (string) wp_rand(100000, 999999);
+           set_transient('acore_2fa_email_code_' . acore_2fa_unlock_key($user->ID), wp_hash($code), 10 * MINUTE_IN_SECONDS);
+           set_transient($rateKey, true, 60);
+
+           $sent = wp_mail(
+               $user->user_email,
+               __('Your security verification code', 'acore-wp-plugin'),
+               sprintf(__('Your verification code is: %s (valid for 10 minutes).', 'acore-wp-plugin'), $code)
+           );
+           if (!$sent)
+               return new \WP_Error('email_failed', __('Could not send the email. Please try again later.'), ['status' => 500]);
+
+           return ['success' => true];
+       }
+   ) );
+
+   // User: verify an emailed code to unlock sensitive panels (same unlock as TOTP)
+   register_rest_route( ACORE_SLUG . '/v1', 'verify-email-2fa', array(
+       'methods'             => 'POST',
+       'permission_callback' => function() { return is_user_logged_in(); },
+       'callback'            => function( \WP_REST_Request $request ) {
+           $user = wp_get_current_user();
+           $key  = 'acore_2fa_email_code_' . acore_2fa_unlock_key($user->ID);
+           $attemptKey = acore_2fa_attempt_key($user->ID);
+           if ((int) get_transient($attemptKey) >= 5)
+               return new \WP_Error('rate_limited', __('Too many incorrect codes. Please wait a few minutes.', 'acore-wp-plugin'), ['status' => 429]);
+
+           $data = $request->get_json_params();
+           $code = isset($data['code']) ? trim((string) $data['code']) : '';
+           if (!preg_match('/^\d{6}$/', $code))
+               return new \WP_Error('invalid_token', __('Please enter a valid 6-digit code.'), ['status' => 400]);
+
+           $stored = get_transient($key);
+           if (!$stored || !hash_equals((string) $stored, wp_hash($code))) {
+               set_transient($attemptKey, ((int) get_transient($attemptKey)) + 1, 10 * MINUTE_IN_SECONDS);
+               return new \WP_Error('wrong_token', __('Incorrect or expired code. Please try again.'), ['status' => 401]);
+           }
+
+           delete_transient($attemptKey);
+           delete_transient($key);
+           set_transient(acore_2fa_unlock_key($user->ID), time(), 30 * MINUTE_IN_SECONDS);
+
+           return ['success' => true];
+       }
+   ) );
+
+   // User: lightweight 2FA status for real-time removal detection on the Security page
+   register_rest_route( ACORE_SLUG . '/v1', '2fa-status', array(
+       'methods'             => 'GET',
+       'permission_callback' => function() { return is_user_logged_in(); },
+       'callback'            => function() {
+           $user = wp_get_current_user();
+           $log  = get_user_meta($user->ID, 'acore_2fa_admin_log', true);
+           $log  = is_array($log) ? $log : [];
+           return [
+               'website_enabled' => acore_website_2fa_enabled($user->ID),
+               'ingame_enabled'  => acore_ingame_2fa_enabled($user->ID),
+               'removal_count'   => count($log),
+           ];
+       }
+   ) );
+
+   // User: paginated connection history (for "see more" without a page reload)
+   register_rest_route( ACORE_SLUG . '/v1', 'connections', array(
+       'methods'             => 'GET',
+       'permission_callback' => function() { return is_user_logged_in(); },
+       'callback'            => function( \WP_REST_Request $request ) {
+           $user    = wp_get_current_user();
+           $perPage = 50;
+           $page    = max(1, (int) $request->get_param('page'));
+
+           $all    = \ACore\Hooks\User\acore_get_login_history($user->ID, 500);
+           $all    = is_array($all) ? $all : [];
+           $total  = count($all);
+           $offset = ($page - 1) * $perPage;
+           $slice  = array_slice($all, $offset, $perPage);
+           $myIp   = \ACore\Hooks\User\acore_resolve_client_ip();
+
+           $rows = array_map(function ($r) use ($myIp) {
+               $ip = $r['ip_address'] ?? ($r['ip'] ?? '');
+               return [
+                   'ip'      => $ip,
+                   'country' => ($r['country'] ?? '') !== '' ? $r['country'] : 'Unknown',
+                   'date'    => ($r['login_at'] ?? '') !== '' ? \ACore\Hooks\User\acore_format_connection_date($r['login_at']) : '',
+                   'where'   => (($r['source'] ?? 'website') === 'ingame') ? 'In-game' : 'Website',
+                   'current' => ($ip !== '' && $ip === $myIp),
+               ];
+           }, $slice);
+
+           return [
+               'rows'     => array_values($rows),
+               'page'     => $page,
+               'total'    => $total,
+               'from'     => $total ? $offset + 1 : 0,
+               'to'       => $offset + count($slice),
+               'has_more' => ($offset + count($slice)) < $total,
+           ];
        }
    ) );
 });

--- a/src/acore-wp-plugin/src/Components/Tools/ToolsApi.php
+++ b/src/acore-wp-plugin/src/Components/Tools/ToolsApi.php
@@ -11,23 +11,31 @@ class ToolsApi {
     }
 
     public static function ItemRestore($data) {
-        $item = $data['item'];
         $cname = $data['cname'];
+        $item  = filter_var($data['item'] ?? null, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+        if ($item === false) {
+            return new \WP_Error('invalid_item', 'Invalid item id.', ['status' => 400]);
+        }
+        if (!ACoreServices::I()->currentAccountOwnsCharacterName($cname)) {
+            return new \WP_Error('forbidden', 'You do not own that character.', ['status' => 403]);
+        }
         return ACoreServices::I()->getServerSoap()->executeCommand("item restore $item $cname");
     }
 }
 
 add_action( 'rest_api_init', function () {
    register_rest_route( ACORE_SLUG . '/v1', 'item-restore/list/(?P<cguid>\d+)', array(
-       'methods'  => 'GET',
-       'callback' => function( $request ) {
+       'methods'             => 'GET',
+       'permission_callback' => function() { return is_user_logged_in(); },
+       'callback'            => function( $request ) {
             return ToolsApi::ItemRestoreList($request);
        }
    ));
 
    register_rest_route( ACORE_SLUG . '/v1', 'item-restore', array(
-    'methods'  => 'POST',
-    'callback' => function( $request ) {
+    'methods'             => 'POST',
+    'permission_callback' => function() { return is_user_logged_in(); },
+    'callback'            => function( $request ) {
 
         // if free item-restoration is disabled, return
         if (Opts::I()->acore_item_restoration != '1') {

--- a/src/acore-wp-plugin/src/Components/UnstuckMenu/UnstuckView.php
+++ b/src/acore-wp-plugin/src/Components/UnstuckMenu/UnstuckView.php
@@ -2,6 +2,8 @@
 
 namespace ACore\Components\UnstuckMenu;
 
+use ACore\Utils\AcoreCharColors;
+
 
 class UnstuckView
 {
@@ -17,10 +19,14 @@ class UnstuckView
         ob_start();
 
         wp_enqueue_style('bootstrap-css', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css', array(), '5.1.3');
-        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.1');
+        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.5');
         wp_enqueue_script('bootstrap-js', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js', array(), '5.1.3');
         wp_enqueue_script('jquery');
         wp_enqueue_script('acore-unstuck-js', ACORE_URL_PLG . 'web/assets/unstuck/unstuck.js', array('jquery'), null, true);
+        wp_localize_script('acore-unstuck-js', 'unstuckData', array(
+            'restUrl' => rest_url(ACORE_SLUG . '/v1/unstuck'),
+            'nonce'   => wp_create_nonce('wp_rest'),
+        ));
 
 ?>
 
@@ -31,7 +37,7 @@ class UnstuckView
                         <h3>Unstuck</h3>
                         <p>Unstuck your characters and teleport them to the hearthstone location</p>
                         <hr>
-                        <ul id="acore-characters-unstuck" class="list-unstyled">
+                        <ul id="acore-characters-unstuck" class="acore-char-list list-unstyled">
                             <?php foreach ($chars as $char) {
                                 $currentTime = time();
                                 $isDisabled = ($char["time"] > $currentTime);
@@ -39,28 +45,26 @@ class UnstuckView
                                 $tooltipText = $isDisabled ? 'Unstuck is on cooldown' : ''; // Tooltip text if disabled
                                 $remainingCDTime = $isDisabled ? $char["time"] - $currentTime : 0;
                                 $endTime = $isDisabled ? $char["time"] : 0;
+                                $clsStyle = AcoreCharColors::rowStyle(intval($char["class"]), intval($char["race"]));
                             ?>
                                 <li>
-                                    <div class="menu-item-bar">
-                                        <div class="menu-item-handle">
-                                            <span class="item-title menu-item-title"><?= $char["name"] ?></span>
-                                            <span class="item-controls">
-                                                <span class="item-type">
-                                                    level <?= $char["level"] ?>&ensp;
-                                                    <img height="32" width="32" src="<?= ACORE_URL_PLG . "web/assets/race/" . $char["race"] . ($char["gender"] == 0 ? "m" : "f") . ".webp"; ?>">
-                                                    <img height="32" width="32" src="<?= ACORE_URL_PLG . "web/assets/class/" . $char["class"] . ".webp"; ?>">
-                                                </span>
-                                                <button
-                                                    class="unstuck-button"
-                                                    data-char-name="<?= $char["name"] ?>"
-                                                    <?= $isDisabled ? 'disabled' : '' ?>
-                                                    title="<?= $tooltipText ?>">
-                                                    <img src="<?php echo ACORE_URL_PLG . 'web/assets/unstuck/hearthstone.jpg'; ?>" alt="Unstuck">
-                                                </button>
-                                                <span class="countdown" id="countdown-<?= $char['name'] ?>" data-end-time="<?= $endTime ?>">
-                                                    <?= $isDisabled ? gmdate("H:i:s", $remainingCDTime) : ''; ?>
-                                                </span>
-                                        </div>
+                                    <div class="acore-char-row" style="<?= esc_attr($clsStyle) ?>">
+                                        <span class="acore-char-name"><?= esc_html($char["name"]) ?></span>
+                                        <span class="acore-char-meta">
+                                            <span class="acore-level" data-exp="<?= AcoreCharColors::expansionSlug(intval($char["level"])) ?>" title="<?= esc_attr(AcoreCharColors::expansionLabel(intval($char["level"]))) ?>">Level <?= intval($char["level"]) ?></span>
+                                            <img class="race-icon" height="32" width="32" title="<?= esc_attr(AcoreCharColors::getRaceName(intval($char["race"]))) ?>" src="<?= esc_url(ACORE_URL_PLG . "web/assets/race/" . intval($char["race"]) . (intval($char["gender"]) == 0 ? "m" : "f") . ".webp") ?>">
+                                            <img class="class-icon" height="32" width="32" title="<?= esc_attr(AcoreCharColors::getClassName(intval($char["class"]))) ?>" src="<?= esc_url(ACORE_URL_PLG . "web/assets/class/" . intval($char["class"]) . ".webp") ?>">
+                                            <button
+                                                class="unstuck-button"
+                                                data-char-name="<?= esc_attr($char["name"]) ?>"
+                                                <?= $isDisabled ? 'disabled' : '' ?>
+                                                title="<?= esc_attr($tooltipText) ?>">
+                                                <img src="<?php echo ACORE_URL_PLG . 'web/assets/unstuck/hearthstone.jpg'; ?>" alt="Unstuck">
+                                            </button>
+                                            <span class="countdown" id="countdown-<?= esc_attr($char['name']) ?>" data-end-time="<?= $endTime ?>">
+                                                <?= $isDisabled ? gmdate("H:i:s", $remainingCDTime) : ''; ?>
+                                            </span>
+                                        </span>
                                     </div>
                                 </li>
                             <?php } ?>
@@ -70,12 +74,6 @@ class UnstuckView
             </div>
         </div>
 
-        <script>
-            var unstuckData = {
-                nonce: "<?php echo wp_create_nonce('wp_rest'); ?>",
-                restUrl: "<?php echo get_rest_url(null, ACORE_SLUG . '/v1/unstuck'); ?>"
-            };
-        </script>
 <?php
         return ob_get_clean();
     }

--- a/src/acore-wp-plugin/src/Components/UserPanel/Pages/ItemRestorationPage.php
+++ b/src/acore-wp-plugin/src/Components/UserPanel/Pages/ItemRestorationPage.php
@@ -1,198 +1,292 @@
 <?php
     use ACore\Manager\Opts;
+    use ACore\Utils\AcoreCharColors;
 ?>
 
 <script>const whTooltips = {colorLinks: true, iconizeLinks: true, renameLinks: true};</script>
-<div class="wrap">
-    <h2><?= __('AzerothCore Settings', Opts::I()->page_alias) ?></h2>
-    <div class="row">
-        <div>
+<div class="wrap" id="acore-item-restoration-page">
+    <h1><?php _e('Item Restoration', Opts::I()->page_alias); ?></h1>
+    <div id="item-restore-layout">
+
+        <!-- Sidebar -->
+        <div id="item-restore-sidebar">
             <div class="card">
                 <div class="card-body">
-                    <h4 class="text-uppercase">Item restoration service</h4>
+                    <h3><?php _e('Item Restoration', Opts::I()->page_alias); ?></h3>
+                    <p><?php _e('Select a character to view their deleted items. Restored items are sent to the mailbox.', Opts::I()->page_alias); ?></p>
                     <hr>
-                    <div style="width: 12em">
-                        <div class="btn-group">
-                            <div class="bg-secondary p-2 text-white border rounded-left" id="activeCharacter">Choose Character</div>
-                            <button type="button" class="button-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-                                <span class="visually-hidden"></span>
-                            </button>
-                            <?php if ($characters): ?>
-                                <ul class="dropdown-menu" id="characterList">
-                            <?php foreach ($characters as $character): ?>
-                                    <li cguid="<?= $character['guid']?>"><a class="dropdown-item" href="#"><?= $character['name']?></a></li>
-                                <?php endforeach; ?>
-                                </ul>
-                            <?php else: ?>
-                                <span>No characters found.</span>
-                            <?php endif; ?>
+
+                    <?php if ($characters): ?>
+                        <strong><?php _e('Select Character:', Opts::I()->page_alias); ?></strong>
+                        <ul id="acore-characters-item-restore" class="acore-char-list list-unstyled mt-2">
+                            <?php foreach ($characters as $char):
+                                $clsStyle = AcoreCharColors::rowStyle(intval($char['class']), intval($char['race']));
+                            ?>
+                                <li>
+                                    <button type="button" class="acore-char-row acore-char-card"
+                                         data-char-guid="<?= intval($char['guid']) ?>"
+                                         data-char-name="<?= esc_attr($char['name']) ?>"
+                                         title="<?= esc_attr(sprintf('Show items that can be restored to %s', $char['name'])) ?>"
+                                         style="<?= esc_attr($clsStyle) ?>">
+                                        <span class="acore-char-name"><?= esc_html($char['name']) ?></span>
+                                        <span class="acore-char-meta">
+                                            <span class="acore-level" data-exp="<?= AcoreCharColors::expansionSlug(intval($char['level'])) ?>" title="<?= esc_attr(AcoreCharColors::expansionLabel(intval($char['level']))) ?>">Level <?= intval($char['level']) ?></span>
+                                            <img class="race-icon" height="32" width="32" title="<?= esc_attr(AcoreCharColors::getRaceName(intval($char['race']))) ?>" src="<?= ACORE_URL_PLG . 'web/assets/race/' . intval($char['race']) . (intval($char['gender']) == 0 ? 'm' : 'f') . '.webp' ?>">
+                                            <img class="class-icon" height="32" width="32" title="<?= esc_attr(AcoreCharColors::getClassName(intval($char['class']))) ?>" src="<?= ACORE_URL_PLG . 'web/assets/class/' . intval($char['class']) . '.webp' ?>">
+                                        </span>
+                                    </button>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php else: ?>
+                        <p><?php _e('No characters found.', Opts::I()->page_alias); ?></p>
+                    <?php endif; ?>
+
+                    <div id="item-restore-loading" style="display:none;" class="text-center my-3">
+                        <div class="spinner-border text-primary" role="status">
+                            <span class="visually-hidden">Loading...</span>
                         </div>
                     </div>
-                    <div id="errorBox" class="text-uppercase text-danger"></div>
-                    <div id="successBox" class="alert alert-success invisible" role="alert"></div>
-                    <p class="text-muted m-0"><em>Restored items will be sent to the selected characters mailbox.</em></p>
-                    <hr>
-                    <div id="item-list-no-content" class="alert alert-info hidden" role="alert">
-                        <span>There is no items to recover for the selected character</span>
-                    </div>
-                    <div class="table-responsive hidden" id="itemContainer">
-                        <table class="table table-bordered table-hover align-middle">
-                            <thead style="background: #1d2327; color: #fff;">
-                                <tr>
-                                    <th scope="col" class="text-uppercase">item name</th>
-                                    <th scope="col" class="text-uppercase">action</th>
-                                </tr>
-                            </thead>
-                            <tbody style="background: #2c3338;" id="itemList">
-                            <?php
-                                for ($i = 0; $i < 5; $i++): 
-                            ?>
-                                <tr class="loading-item-list hidden">
-                                    <td class="placeholder-glow"><p><span class="placeholder col-12 bg-secondary"></span></p></td>
-                                    <td><p class="placeholder-glow"><span class="placeholder col-12"></span></p></td>
-                                </tr>
-                            <?php endfor; ?>
-                            </tbody>
-                        </table>
+
+                    <!-- Empty state stays in sidebar -->
+                    <div id="item-list-no-content" style="display:none;">
+                        <hr>
+                        <p class="text-muted mb-0"><?php _e('There are no items to recover for the selected character.', Opts::I()->page_alias); ?></p>
                     </div>
                 </div>
             </div>
-        </div>
-    </div>
+        </div><!-- /item-restore-sidebar -->
+
+        <!-- Content: item cards, hidden until loaded -->
+        <div id="item-restore-content" style="display:none;">
+            <div class="card">
+                <div class="card-body">
+                    <div id="item-restore-error" class="text-uppercase text-danger mb-2"></div>
+                    <div id="item-restore-success" class="alert alert-success invisible mb-2" role="alert"></div>
+                    <h5 class="mb-3"><?php _e('Deleted Items', Opts::I()->page_alias); ?></h5>
+                    <div id="item-restore-grid" class="item-restore-grid"></div>
+                </div>
+            </div>
+        </div><!-- /item-restore-content -->
+
+    </div><!-- /item-restore-layout -->
 </div>
 
 <script>
-    // Register event listeners & element specifiers
-    const characters = document.querySelectorAll('#characterList li');
-    const itemContainer = document.getElementById('itemContainer');
-    const itemList = document.getElementById('itemList');
-    const itemListLoaders = document.querySelectorAll('.loading-item-list');
-    const activeCharacter = document.getElementById('activeCharacter');
-    const error = document.getElementById('errorBox');
-    const success = document.getElementById('successBox');
-    const noResults =  document.getElementById('item-list-no-content');
-    characters.forEach(character => character.addEventListener('click', selectCharacter));
+(function () {
+    var content    = document.getElementById('item-restore-content');
+    var grid       = document.getElementById('item-restore-grid');
+    var errorBox   = document.getElementById('item-restore-error');
+    var successBox = document.getElementById('item-restore-success');
+    var noResults  = document.getElementById('item-list-no-content');
+    var loading    = document.getElementById('item-restore-loading');
 
-    // Character Selection
-    function selectCharacter() {
-        resetState();
-        itemListLoaders.forEach(element => element.classList.remove('hidden'));
-        itemContainer.classList.remove('hidden');
-        const character = this.getAttribute('cguid');
-        const characterName = this.firstChild.innerHTML;
-        activeCharacter.innerHTML = characterName;
+    var listUrl    = '<?= esc_js(get_rest_url(null, ACORE_SLUG . '/v1/item-restore/list/')) ?>';
+    var restoreUrl = '<?= esc_js(get_rest_url(null, ACORE_SLUG . '/v1/item-restore')) ?>';
+    var restNonce  = '<?= esc_js(wp_create_nonce('wp_rest')) ?>';
 
-        fetch('<?= get_rest_url(null, 'acore/v1/item-restore/list/'); ?>' + character)
-        .then(function(response) {
-            return response.json();
-        }).then(function(items) {
-            if (!items || !items.length > 0) {
-                noResults.classList.remove('hidden');
-                return;
+    function parseJsonResponse(response) {
+        return response.json().catch(function () { return {}; }).then(function (body) {
+            if (!response.ok) {
+                throw new Error((body && body.message) ? body.message : 'Request failed.');
             }
-
-            items.forEach(item => {
-                const row = itemList.insertRow();
-                row.id = "row" + item['Id'];
-
-                // Item
-                const itemCell = row.insertCell();
-                const itemLink = document.createElement('a');
-                itemLink.href = "#";
-                itemLink.setAttribute('data-wowhead', `item=${item['ItemEntry']}`);
-                itemCell.appendChild(itemLink);
-
-                // Button
-                const buttonCell = row.insertCell();
-                const button = document.createElement('button');
-                button.classList.add('button-primary', 'text-uppercase');
-                button.setAttribute('type', 'button');
-                button.setAttribute('item', item['Id']);
-                button.setAttribute('cname', characterName);
-                button.appendChild(document.createTextNode('restore'));
-                button.addEventListener('click', restoreItem);
-                buttonCell.appendChild(button);
-            });
-
-            checkHasRecoverableItems();
-        })
-        .catch((msg) => {
-            error.innerHTML = msg;
-        })
-        .finally(() => {
-            $WowheadPower.refreshLinks();
-            itemListLoaders.forEach(element => element.classList.add('hidden'));
+            return body;
         });
     }
 
-    // Restore Item
-    function restoreItem() {
+    // wowhead quality class → card border colour
+    var wowQualityColors = {
+        q0: '#9d9d9d', q1: '#c0c0c0', q2: '#1eff00',
+        q3: '#0070dd', q4: '#a335ee', q5: '#ff8000',
+        q6: '#e6cc80', q7: '#e6cc80'
+    };
+
+    document.querySelectorAll('#acore-characters-item-restore .acore-char-row').forEach(function (row) {
+        row.addEventListener('click', function () {
+            document.querySelectorAll('#acore-characters-item-restore .acore-char-row').forEach(function (r) {
+                r.classList.remove('active');
+            });
+            row.classList.add('active');
+            selectCharacter(row.getAttribute('data-char-guid'), row.getAttribute('data-char-name'));
+        });
+    });
+
+    function selectCharacter(guid, characterName) {
         resetState();
-        const item = this.getAttribute('item');
-        const cname = this.getAttribute('cname');
+        loading.style.display = 'block';
+        content.style.display = 'none';
+        grid.innerHTML = '';
 
-        const loadingDiv = document.createElement('div');
-        const loader = document.createElement('span');
-        loader.classList.add('placeholder', 'col-12', 'bg-warning');
-        loadingDiv.classList.add('placeholder-glow');
-        loadingDiv.appendChild(loader);
-        this.parentElement.appendChild(loadingDiv);
-        this.parentElement.removeChild(this);
-        fetch('<?= get_rest_url(null, 'acore/v1/item-restore'); ?>', {
-            method: "POST",
-            headers: {
-                'Accept': 'application/json',
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                item: item,
-                cname: cname,
-            }),
-        })
-        .then(function(response) {
-            return response.json();
-        }).then(function(data) {
-            if (data.toLowerCase().includes('mail')) {
-                success.innerHTML = data;
-                document.getElementById('row' + item).parentElement.removeChild(document.getElementById('row' + item))
-                success.classList.remove('invisible');
+        fetch(listUrl + guid, { headers: { 'Accept': 'application/json', 'X-WP-Nonce': restNonce } })
+            .then(parseJsonResponse)
+            .then(function (items) {
+                loading.style.display = 'none';
 
-                checkHasRecoverableItems();
-            } 
-            else error.innerHTML = data;
-        })
-        .catch((msg) => {
-            error.innerHTML = msg;
-        });        
+                if (!items || !items.length) {
+                    noResults.style.display = 'block';
+                    return;
+                }
+
+                content.style.display = 'block';
+
+                items.forEach(function (item, index) {
+                    var card = document.createElement('div');
+                    card.className = 'item-restore-card';
+                    card.id = 'card' + item['Id'];
+
+                    // Number badge
+                    var num = document.createElement('span');
+                    num.className = 'item-restore-num';
+                    num.textContent = index + 1;
+                    num.title = 'Position in your list of restorable items.';
+
+                    // Icon container — wowhead puts the icon as background-image on the <a>
+                    var iconWrap = document.createElement('div');
+                    iconWrap.className = 'item-restore-icon';
+
+                    var link = document.createElement('a');
+                    link.href = 'https://www.wowhead.com/wotlk/item=' + item['ItemEntry'];
+                    link.setAttribute('data-wowhead', 'item=' + item['ItemEntry']);
+
+                    iconWrap.appendChild(link);
+
+                    // Restore button
+                    var btn = document.createElement('button');
+                    btn.className = 'item-restore-btn';
+                    btn.type = 'button';
+                    btn.textContent = 'Restore';
+                    btn.title = 'Send this item back to ' + characterName + ' by in-game mail.';
+                    (function (itemId, charName, cardEl, btnEl) {
+                        btnEl.addEventListener('click', function () {
+                            restoreItem(itemId, charName, cardEl, btnEl);
+                        });
+                    })(item['Id'], characterName, card, btn);
+
+                    // Delete date
+                    var dateEl = document.createElement('span');
+                    dateEl.className = 'item-restore-date';
+                    dateEl.title = 'Date this item was deleted.';
+                    var d = item['DeleteDate'];
+                    if (d) {
+                        var dStr = String(d);
+                        var dt   = /^\d+$/.test(dStr) ? new Date(Number(dStr) * 1000) : new Date(dStr.replace(' ', 'T'));
+                        if (!isNaN(dt.getTime())) {
+                            var day = dt.getDate();
+                            var ord = day % 100 >= 11 && day % 100 <= 13 ? 'th'
+                                : day % 10 === 1 ? 'st'
+                                : day % 10 === 2 ? 'nd'
+                                : day % 10 === 3 ? 'rd' : 'th';
+                            var months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+                            var hh = String(dt.getHours()).padStart(2, '0');
+                            var mm = String(dt.getMinutes()).padStart(2, '0');
+                            dateEl.textContent = day + ord + ' of ' + months[dt.getMonth()] + ', ' + dt.getFullYear() + ' at ' + hh + ':' + mm;
+                        } else {
+                            dateEl.textContent = String(d);
+                        }
+                    } else {
+                        dateEl.textContent = '';
+                    }
+
+                    card.appendChild(num);
+                    card.appendChild(iconWrap);
+                    card.appendChild(dateEl);
+                    card.appendChild(btn);
+                    grid.appendChild(card);
+                });
+
+                applyWowheadIcons();
+            })
+            .catch(function (msg) {
+                loading.style.display = 'none';
+                errorBox.textContent = msg && msg.message ? msg.message : String(msg);
+            });
     }
 
-    function checkHasRecoverableItems() {
-        // 5 is minimum count due to placeholders (loaders)
-        if (itemList.childElementCount == 5) {
-            const row = itemList.insertRow();
-            row.id = "no-recoverable-items";
-            const spanCell = row.insertCell();
-            const infoSpan = document.createElement('span');
-            infoSpan.style = "color: #fff";
-            infoSpan.innerHTML = "No items to recover for the selected character.";
-            spanCell.appendChild(infoSpan);
-            
-            // Add empty cell as well (to fill otherwise empty whitespace)
-            row.insertCell();
+    function restoreItem(id, characterName, cardEl, btnEl) {
+        resetState();
+        btnEl.disabled = true;
+        btnEl.textContent = '...';
+
+        fetch(restoreUrl, {
+            method: 'POST',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json', 'X-WP-Nonce': restNonce },
+            body: JSON.stringify({ item: id, cname: characterName }),
+        })
+            .then(parseJsonResponse)
+            .then(function (data) {
+                if (typeof data === 'string' && data.toLowerCase().includes('mail')) {
+                    cardEl.parentElement.removeChild(cardEl);
+                    successBox.textContent = data;
+                    successBox.classList.remove('invisible');
+                    // renumber remaining cards
+                    var remaining = grid.querySelectorAll('.item-restore-card');
+                    remaining.forEach(function (c, i) {
+                        var n = c.querySelector('.item-restore-num');
+                        if (n) n.textContent = i + 1;
+                    });
+                    if (remaining.length === 0) {
+                        content.style.display = 'none';
+                        noResults.style.display = 'block';
+                    }
+                } else {
+                    errorBox.textContent = typeof data === 'string' ? data : JSON.stringify(data);
+                    btnEl.disabled = false;
+                    btnEl.textContent = 'Restore';
+                }
+            })
+            .catch(function (err) {
+                errorBox.textContent = err && err.message ? err.message : 'An error occurred.';
+                btnEl.disabled = false;
+                btnEl.textContent = 'Restore';
+            });
+    }
+
+    function applyWowheadIcons() {
+        function doApply() {
+            document.querySelectorAll('.item-restore-icon > a').forEach(function (a) {
+                // upgrade icon to large JPG
+                var bg = a.style.backgroundImage;
+                if (bg) {
+                    bg = bg.replace(/\/icons\/(tiny|small)\//, '/icons/large/')
+                           .replace(/\.gif(["']?\))/, '.jpg$1');
+                    a.style.backgroundImage = bg;
+                }
+                // read quality class (q0-q7) and apply to card border
+                var card = a.closest('.item-restore-card');
+                if (card) {
+                    for (var cls in wowQualityColors) {
+                        if (a.classList.contains(cls)) {
+                            card.style.borderColor = wowQualityColors[cls];
+                            break;
+                        }
+                    }
+                }
+            });
         }
 
-        else {
-            const infoRow = document.getElementById('no-recoverable-items');
-            if (infoRow) {
-                infoRow.parentElement.removeChild(infoRow);
-            }
+        if (typeof $WowheadPower !== 'undefined' && $WowheadPower.refreshLinks) {
+            $WowheadPower.refreshLinks();
+            setTimeout(doApply, 1500);
+        } else {
+            var attempts = 0;
+            var wait = setInterval(function () {
+                attempts++;
+                if (typeof $WowheadPower !== 'undefined' && $WowheadPower.refreshLinks) {
+                    $WowheadPower.refreshLinks();
+                    clearInterval(wait);
+                    setTimeout(doApply, 1500);
+                } else if (attempts > 20) {
+                    clearInterval(wait);
+                }
+            }, 250);
         }
     }
 
     function resetState() {
-        success.innerHTML = "";
-        error.innerHTML = "";
-        success.classList.add('invisible');
-        noResults.classList.add('hidden');
+        errorBox.textContent = '';
+        successBox.textContent = '';
+        successBox.classList.add('invisible');
+        noResults.style.display = 'none';
     }
+})();
 </script>

--- a/src/acore-wp-plugin/src/Components/UserPanel/Pages/RafProgressPage.php
+++ b/src/acore-wp-plugin/src/Components/UserPanel/Pages/RafProgressPage.php
@@ -7,18 +7,22 @@ $user = wp_get_current_user();
 $acServices = ACoreServices::I();
 $userId = $acServices->getAcoreAccountId();
 ?>
-<div class="wrap">
-    <?php
-    echo "<h2>" . __('Recruit a Friend', Opts::I()->page_alias) . "</h2>";
-    ?>
-    <p>Recruit your friends, help them to level up and get very awesome unique prizes.</p>
+<div class="wrap" id="acore-raf-page">
+    <h1><?php _e('Recruit a Friend', Opts::I()->page_alias); ?></h1>
+    <p class="acore-raf-intro"><?php _e('Recruit your friends, help them level up and earn unique rewards.', Opts::I()->page_alias); ?></p>
+
     <?php if (Opts::I()->eluna_raf_config['end_raf_on_same_ip'] === '1') { ?>
-    <p style="color: red; font-size: 20px;">Recruiting from the same IP address will cause the RAF to be automatically removed and no new RAF can be applied again.</p>
+    <div class="notice notice-warning inline acore-raf-notice">
+        <p><?php _e('Recruiting from the same IP address will cause the RAF to be automatically removed and no new RAF can be applied.', Opts::I()->page_alias); ?></p>
+    </div>
     <?php } else { ?>
-    <p style="color: red; font-size: 20px;">Whilst you can recruit a friend who shares an IP address, you will only get the teleport &amp; XP bonuses, no rewards will be given (these are provided only to those who recruit people not on their own IP address).</p>
+    <div class="notice notice-warning inline acore-raf-notice">
+        <p><?php _e('You can recruit a friend who shares your IP address, however only the teleport & XP bonuses apply - rewards are reserved for recruits on different IP addresses.', Opts::I()->page_alias); ?></p>
+    </div>
     <?php } ?>
-    <div class="row">
-        <div class="col-sm-6">
+
+    <div class="row acore-raf-row">
+        <div class="col-lg-8 col-md-10 col-sm-12">
             <div class="card">
                 <div class="card-body">
                     <?php
@@ -28,6 +32,7 @@ $userId = $acServices->getAcoreAccountId();
                         <?php if ($maxRecruitDatetime >= (new \DateTime())) { ?>
                         <p>You still have until <b><?php echo $maxRecruitDatetime->format('D, d M Y H:i'); ?> [server time]</b> to be recruited by a friend, enter his username here: </p>
                         <form method="post">
+                            <?php wp_nonce_field('acore_raf_recruit', 'acore_raf_nonce'); ?>
                             <p>
                                 <input type="text" name="recruited" value="" placeholder="Recruiter code" size="20" required />
                                 <input type="submit" name="Submit" class="button-primary" value="Recruit me!" />

--- a/src/acore-wp-plugin/src/Components/UserPanel/Pages/SecurityPage.php
+++ b/src/acore-wp-plugin/src/Components/UserPanel/Pages/SecurityPage.php
@@ -1,0 +1,678 @@
+<?php
+defined('ABSPATH') || exit;
+
+$user = wp_get_current_user();
+$changedLabel = $passwordChangedAt
+    ? \ACore\Hooks\User\acore_format_connection_date($passwordChangedAt)
+    : __('Never', 'acore-wp-plugin');
+$expandOnLoad = !empty($passwordMessage);
+?>
+
+<div class="wrap" id="acore-security-page">
+    <h1><?php _e('Security', 'acore-wp-plugin'); ?></h1>
+
+    <div class="postbox">
+        <div class="postbox-header">
+            <h2 class="hndle"><span><?php _e('Password', 'acore-wp-plugin'); ?></span></h2>
+        </div>
+        <div class="inside">
+
+            <?php if (!empty($passwordMessage)): ?>
+                <div class="notice notice-<?= esc_attr($passwordMessage['type']) ?> inline" style="margin:0 0 16px;">
+                    <p><?= esc_html($passwordMessage['text']) ?></p>
+                </div>
+            <?php endif; ?>
+
+            <p style="margin:0 0 14px;">
+                <span style="color:#646970;"><?php _e('Password last updated:', 'acore-wp-plugin'); ?></span>
+                <strong style="margin-left:6px;"><?= esc_html($changedLabel) ?></strong>
+            </p>
+
+            <button type="button" id="acore-set-password-btn" class="button">
+                <?php _e('Set New Password', 'acore-wp-plugin'); ?>
+            </button>
+
+            <div id="acore-password-form-wrap" style="<?= $expandOnLoad ? '' : 'display:none;' ?>margin-top:20px;">
+                <form method="post" id="acore-password-form">
+                    <?php wp_nonce_field('acore_security_change_password', 'acore_pw_nonce'); ?>
+                    <table class="form-table" role="presentation">
+                        <tr>
+                            <th scope="row">
+                                <label for="acore_old_pass"><?php _e('Current Password', 'acore-wp-plugin'); ?></label>
+                            </th>
+                            <td>
+                                <div class="acore-pw-field">
+                                    <input type="password" name="acore_old_pass" id="acore_old_pass"
+                                        class="regular-text" autocomplete="current-password" />
+                                    <button type="button" class="acore-pw-toggle button" aria-label="<?php _e('Show password', 'acore-wp-plugin'); ?>">
+                                        <span class="dashicons dashicons-visibility"></span>
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">
+                                <label for="acore_new_pass"><?php _e('New Password', 'acore-wp-plugin'); ?></label>
+                            </th>
+                            <td>
+                                <div class="acore-pw-field">
+                                    <input type="password" name="acore_new_pass" id="acore_new_pass"
+                                        class="regular-text" autocomplete="new-password" />
+                                    <button type="button" class="acore-pw-toggle button" aria-label="<?php _e('Show password', 'acore-wp-plugin'); ?>">
+                                        <span class="dashicons dashicons-visibility"></span>
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">
+                                <label for="acore_confirm_pass"><?php _e('Confirm New Password', 'acore-wp-plugin'); ?></label>
+                            </th>
+                            <td>
+                                <div class="acore-pw-field">
+                                    <input type="password" name="acore_confirm_pass" id="acore_confirm_pass"
+                                        class="regular-text" autocomplete="new-password" />
+                                    <button type="button" class="acore-pw-toggle button" aria-label="<?php _e('Show password', 'acore-wp-plugin'); ?>">
+                                        <span class="dashicons dashicons-visibility"></span>
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                    <p class="submit" style="margin-top:4px;">
+                        <button type="submit" name="acore_change_password" class="button button-primary">
+                            <?php _e('Save Password', 'acore-wp-plugin'); ?>
+                        </button>
+                        <button type="button" id="acore-cancel-password-btn" class="button" style="margin-left:6px;">
+                            <?php _e('Cancel', 'acore-wp-plugin'); ?>
+                        </button>
+                    </p>
+                </form>
+            </div>
+
+        </div>
+    </div>
+
+    <?php
+    $websiteTotpEnabled  = !empty($twoFaData['plugin_active']) && !empty($twoFaData['totp_enabled']);
+    $websiteEmailEnabled = !empty($twoFaData['plugin_active']) && !empty($twoFaData['email_enabled']);
+    $websiteAnyEnabled   = $websiteTotpEnabled || $websiteEmailEnabled;
+    $twofaUnlocked       = $websiteAnyEnabled && (bool) get_transient(\ACore\Components\ServerInfo\acore_2fa_unlock_key($user->ID));
+    $restBase         = rest_url(ACORE_SLUG . '/v1/remove-ingame-2fa');
+    $verifyBase       = rest_url(ACORE_SLUG . '/v1/verify-website-2fa');
+    $emailRequestBase = rest_url(ACORE_SLUG . '/v1/request-email-2fa');
+    $emailVerifyBase  = rest_url(ACORE_SLUG . '/v1/verify-email-2fa');
+    $statusBase = rest_url(ACORE_SLUG . '/v1/2fa-status');
+    $restNonce  = wp_create_nonce('wp_rest');
+
+    // Admin-removal log: find last entry per type
+    $adminLog         = get_user_meta($user->ID, 'acore_2fa_admin_log', true);
+    $adminLog         = is_array($adminLog) ? $adminLog : [];
+    $lastWebRemoval    = null;
+    $lastGameRemoval   = null;
+    $lastBackupRemoval = null;
+    foreach ($adminLog as $entry) {
+        if ($entry['type'] === 'website') $lastWebRemoval    = $entry;
+        if ($entry['type'] === 'ingame')  $lastGameRemoval   = $entry;
+        if ($entry['type'] === 'backup')  $lastBackupRemoval = $entry;
+    }
+    $backupCodesMeta = get_user_meta($user->ID, 'wp_2fa_backup_codes', true);
+    $backupCodesLeft = is_array($backupCodesMeta) ? count($backupCodesMeta) : 0;
+    // Only warn if 2FA is not currently active (user hasn't re-enabled yet)
+    $showWebWarning    = $lastWebRemoval    && !$websiteAnyEnabled;
+    $showGameWarning   = $lastGameRemoval   && !$ingame2faActive;
+    $showBackupWarning = $lastBackupRemoval && $backupCodesLeft === 0;
+    ?>
+
+    <div class="postbox">
+        <div class="postbox-header">
+            <h2 class="hndle"><span><?php _e('Two-Factor Authentication', 'acore-wp-plugin'); ?></span></h2>
+        </div>
+        <div class="inside">
+
+            <?php if ($showWebWarning || $showGameWarning || $showBackupWarning): ?>
+                <div class="notice notice-warning inline" style="margin:0 0 18px; padding:10px 14px;">
+                    <p style="margin:0 0 4px; font-weight:600;">
+                        <span class="dashicons dashicons-warning" style="color:#dba617; margin-right:4px; vertical-align:middle;"></span>
+                        <?php _e('Your two-factor authentication was removed.', 'acore-wp-plugin'); ?>
+                    </p>
+                    <?php if ($showWebWarning): ?>
+                        <p style="margin:4px 0 0; font-size:13px;">
+                            - <?php
+                            $webDate = '<strong>' . esc_html(wp_date('jS \o\f F, Y \a\t H:i', $lastWebRemoval['timestamp'])) . '</strong>';
+                            if (($lastWebRemoval['by'] ?? 'admin') === 'self') {
+                                printf(
+                                    __('Website 2FA was manually removed by you on %1$s (last IP: %2$s). Please re-enable it for account security.', 'acore-wp-plugin'),
+                                    $webDate,
+                                    '<strong>' . esc_html($lastWebRemoval['ip'] ?? __('unknown', 'acore-wp-plugin')) . '</strong>'
+                                );
+                            } else {
+                                printf(
+                                    __('Website 2FA was manually removed by an administrator on %1$s. Please re-enable it for account security.', 'acore-wp-plugin'),
+                                    $webDate
+                                );
+                            }
+                            ?>
+                        </p>
+                    <?php endif; ?>
+                    <?php if ($showGameWarning): ?>
+                        <p style="margin:4px 0 0; font-size:13px;">
+                            - <?php
+                            printf(
+                                __('In-game 2FA was manually removed by an administrator on %1$s. Please re-enable it for account security.', 'acore-wp-plugin'),
+                                '<strong>' . esc_html(wp_date('jS \o\f F, Y \a\t H:i', $lastGameRemoval['timestamp'])) . '</strong>'
+                            ); ?>
+                        </p>
+                    <?php endif; ?>
+                    <?php if ($showBackupWarning): ?>
+                        <p style="margin:4px 0 0; font-size:13px;">
+                            - <?php
+                            printf(
+                                __('Your two-factor backup codes were removed by an administrator on %1$s. Please generate new backup codes.', 'acore-wp-plugin'),
+                                '<strong>' . esc_html(wp_date('jS \o\f F, Y \a\t H:i', $lastBackupRemoval['timestamp'])) . '</strong>'
+                            ); ?>
+                        </p>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
+
+            <p style="margin:0 0 16px;">
+                <?php _e('You will need an authenticator app (such as Google Authenticator or any app of your choice) configured with a <strong>Time-based (TOTP)</strong> key.', 'acore-wp-plugin'); ?>
+                <?php _e('Keep in mind there are <strong>two separate setups</strong>: one exclusively for logging into the website, and another for logging into the game server. Each has its own independent code.', 'acore-wp-plugin'); ?>
+            </p>
+
+            <hr style="margin:0 0 20px;">
+
+            <!-- ── Website 2FA ─────────────────────────────────────── -->
+            <h3 style="margin:0 0 12px;"><?php _e('Website', 'acore-wp-plugin'); ?></h3>
+
+            <?php if (!empty($twoFaData['plugin_active'])): ?>
+                <?php
+                global $wp_filter;
+                ob_start();
+                if (!empty($wp_filter['show_user_profile'])) {
+                    foreach ($wp_filter['show_user_profile']->callbacks as $callbacks) {
+                        foreach ($callbacks as $cb) {
+                            $func = $cb['function'];
+                            $id   = '';
+                            if (is_array($func) && is_object($func[0]))      $id = get_class($func[0]);
+                            elseif (is_array($func) && is_string($func[0]))  $id = $func[0];
+                            elseif (is_string($func))                         $id = $func;
+                            if ($id && (
+                                stripos($id, 'WP2FA')      !== false ||
+                                stripos($id, 'wp_2fa')     !== false ||
+                                stripos($id, 'Two_Factor') !== false
+                            )) {
+                                call_user_func($func, $user);
+                            }
+                        }
+                    }
+                }
+                $wp2faHtml = ob_get_clean();
+                // Strip the WP2FA section heading + subtitle (redundant with our own "Website" label)
+                $wp2faHtml = preg_replace(
+                    '/<h[1-4][^>]*>\s*Two-factor authentication settings\s*<\/h[1-4]>\s*(<p[^>]*>[^<]*<\/p>)?/i',
+                    '',
+                    $wp2faHtml
+                );
+                ?>
+
+                <?php if ($twofaUnlocked): ?>
+                    <!-- Already unlocked recently: show the management UI directly (no re-prompt on refresh) -->
+                    <div id="acore-2fa-panel" style="margin-top:16px;">
+                        <?= $wp2faHtml ?>
+                    </div>
+                <?php elseif ($websiteTotpEnabled): ?>
+                    <!-- 2FA is enabled: require a current TOTP code before revealing the management UI (incl. backup codes) -->
+                    <div id="acore-2fa-gate">
+                        <p style="margin:0 0 8px; color:#646970; font-size:13px;">
+                            <?php _e('For your security, enter your current website 2FA code to view or regenerate your backup codes and 2FA settings.', 'acore-wp-plugin'); ?>
+                        </p>
+                        <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+                            <input type="text" id="acore-2fa-gate-code" inputmode="numeric" pattern="\d{6}"
+                                   maxlength="6" placeholder="000000" autocomplete="one-time-code"
+                                   style="width:110px; text-align:center; letter-spacing:0.2em; font-size:18px;">
+                            <button type="button" id="acore-2fa-gate-btn" class="button button-primary">
+                                <?php _e('Unlock', 'acore-wp-plugin'); ?>
+                            </button>
+                        </div>
+                        <div id="acore-2fa-gate-msg" style="font-size:13px; margin-top:8px;"></div>
+                    </div>
+                    <div id="acore-2fa-panel" style="display:none; margin-top:16px;">
+                        <?= $wp2faHtml ?>
+                    </div>
+                <?php elseif ($websiteEmailEnabled): ?>
+                    <!-- Email-based 2FA: email a one-time code, then reveal the management UI -->
+                    <div id="acore-2fa-gate-email">
+                        <p style="margin:0 0 8px; color:#646970; font-size:13px;">
+                            <?php _e('For your security, request a code by email and enter it to view or regenerate your backup codes and 2FA settings.', 'acore-wp-plugin'); ?>
+                        </p>
+                        <p style="margin:0 0 8px;">
+                            <button type="button" id="acore-2fa-email-send" class="button">
+                                <?php _e('Email me a code', 'acore-wp-plugin'); ?>
+                            </button>
+                        </p>
+                        <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+                            <input type="text" id="acore-2fa-email-code" inputmode="numeric" pattern="\d{6}"
+                                   maxlength="6" placeholder="000000" autocomplete="one-time-code"
+                                   style="width:110px; text-align:center; letter-spacing:0.2em; font-size:18px;">
+                            <button type="button" id="acore-2fa-email-verify" class="button button-primary">
+                                <?php _e('Unlock', 'acore-wp-plugin'); ?>
+                            </button>
+                        </div>
+                        <div id="acore-2fa-email-msg" style="font-size:13px; margin-top:8px;"></div>
+                    </div>
+                    <div id="acore-2fa-panel" style="display:none; margin-top:16px;">
+                        <?= $wp2faHtml ?>
+                    </div>
+                <?php else: ?>
+                    <!-- 2FA not set up yet: show the plugin UI directly so the user can configure it -->
+                    <?= $wp2faHtml ?>
+                <?php endif; ?>
+
+            <?php else: ?>
+                <p style="color:#646970;"><?php _e('Two-Factor Authentication plugin is not active.', 'acore-wp-plugin'); ?></p>
+            <?php endif; ?>
+
+            <hr style="margin:20px 0;">
+
+            <!-- ── In-game 2FA ─────────────────────────────────────── -->
+            <h3 style="margin:0 0 4px;">
+                <?php _e('In-game', 'acore-wp-plugin'); ?>
+                <?php if ($ingame2faActive): ?>
+                    <span style="display:inline-block; font-size:11px; font-weight:700; background:#00a32a; color:#fff; padding:2px 8px; border-radius:3px; vertical-align:middle; text-transform:uppercase; letter-spacing:0.05em;">
+                        <?php _e('Enabled', 'acore-wp-plugin'); ?>
+                    </span>
+                <?php else: ?>
+                    <span style="display:inline-block; font-size:11px; font-weight:700; background:#8b949e; color:#fff; padding:2px 8px; border-radius:3px; vertical-align:middle; text-transform:uppercase; letter-spacing:0.05em;">
+                        <?php _e('Disabled', 'acore-wp-plugin'); ?>
+                    </span>
+                <?php endif; ?>
+            </h3>
+
+            <?php if (!$websiteAnyEnabled): ?>
+                <!-- Website 2FA not set up -  grey out entire in-game block with notice -->
+                <div class="acore-2fa-disabled">
+            <?php endif; ?>
+
+            <?php if (!$ingame2faActive): ?>
+                <!-- In-game 2FA disabled -  show setup instructions -->
+                <p style="margin:12px 0 8px; color:#646970; font-size:13px;">
+                    <?php _e('To enable in-game 2FA, follow these steps inside the game:', 'acore-wp-plugin'); ?>
+                </p>
+                <ol style="margin:0 0 0 18px; font-size:13px; line-height:1.8;">
+                    <li>
+                        <?php _e('Log into any character and type', 'acore-wp-plugin'); ?>
+                        <code style="margin-left:4px;">.account 2fa setup 1</code>
+                    </li>
+                    <li>
+                        <?php _e('The game will display your <strong>2FA Key</strong>, for example:', 'acore-wp-plugin'); ?>
+                        <code style="margin-left:4px;">K6NXC763GDQTZJG3CTH4WIOGAW6MZYOO</code>
+                    </li>
+                    <li>
+                        <?php _e('Type it (or copy &amp; paste) into the authenticator app on your phone.', 'acore-wp-plugin'); ?>
+                        <br><em style="opacity:0.85;"><?php _e('Tip: to copy text from the in-game chat you can use an addon such as Prat (3.3.5).', 'acore-wp-plugin'); ?></em>
+                    </li>
+                    <li>
+                        <?php _e('When adding the key in your app, set the key type to <strong>Time based</strong> (TOTP).', 'acore-wp-plugin'); ?>
+                    </li>
+                    <li>
+                        <?php _e('Your app will show a 6-digit code that refreshes every few seconds. Use the code currently shown - if it is about to refresh, wait for a fresh one to avoid errors.', 'acore-wp-plugin'); ?>
+                    </li>
+                    <li>
+                        <?php _e('Back in game, type', 'acore-wp-plugin'); ?>
+                        <code style="margin-left:4px;">.account 2fa setup &lt;6-digit-code&gt;</code>
+                        <?php _e('- replace &lt;6-digit-code&gt; with your actual 6-digit code, <strong>without</strong> the &lt; &gt; brackets.', 'acore-wp-plugin'); ?>
+                    </li>
+                    <li>
+                        <?php _e('You are all set. Close the game client and open it again - it will now ask for your 6-digit code at login.', 'acore-wp-plugin'); ?>
+                    </li>
+                </ol>
+            <?php else: ?>
+                <!-- In-game 2FA enabled - show remove form -->
+                <p style="margin:12px 0 8px; color:#646970; font-size:13px;">
+                    <?php _e('To disable in-game 2FA, enter your current website 2FA code below:', 'acore-wp-plugin'); ?>
+                </p>
+
+                <div id="acore-ingame-2fa-wrap">
+                    <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap; margin-bottom:10px;">
+                        <input type="text" id="acore-ingame-2fa-code" inputmode="numeric" pattern="\d{6}"
+                               maxlength="6" placeholder="000000"
+                               style="width:110px; text-align:center; letter-spacing:0.2em; font-size:18px;">
+                        <button type="button" id="acore-ingame-2fa-remove" class="button button-primary">
+                            <?php _e('Remove In-game 2FA', 'acore-wp-plugin'); ?>
+                        </button>
+                    </div>
+                    <div id="acore-ingame-2fa-msg" style="font-size:13px;"></div>
+                </div>
+            <?php endif; ?>
+
+            <?php if (!$websiteAnyEnabled): ?>
+                </div><!-- /greyed-out wrapper -->
+                <p class="acore-2fa-required-note">
+                    <span class="dashicons dashicons-lock"></span>
+                    <?php _e('Website 2FA must be set up before you can manage In-game 2FA here.', 'acore-wp-plugin'); ?>
+                </p>
+            <?php endif; ?>
+
+        </div><!-- /postbox inside -->
+    </div><!-- /postbox 2FA -->
+
+    <!-- ── Recent Connections ──────────────────────────────────────────── -->
+    <div class="postbox">
+        <div class="postbox-header">
+            <h2 class="hndle acore-conn-heading"><span><?php _e('Recent Connections', 'acore-wp-plugin'); ?></span><span class="acore-conn-myip"><?php _e('Your IPv4:', 'acore-wp-plugin'); ?> <?= esc_html(\ACore\Hooks\User\acore_resolve_client_ip()) ?></span></h2>
+        </div>
+        <div class="inside">
+
+            <?php
+            $myIp     = \ACore\Hooks\User\acore_resolve_client_ip();
+            $perPage  = 50;
+            $total    = is_array($connections) ? count($connections) : 0;
+            $maxPage  = max(1, (int) ceil($total / $perPage));
+            $connPage = max(1, min($maxPage, (int) ($_GET['conn_page'] ?? 1)));
+            $offset   = ($connPage - 1) * $perPage;
+            $pageRows = array_slice((array) $connections, $offset, $perPage);
+            $from     = $total ? $offset + 1 : 0;
+            $to       = $offset + count($pageRows);
+            ?>
+
+            <?php if (empty($connections)): ?>
+                <p class="acore-conn-note"><?php _e('No connections recorded yet.', 'acore-wp-plugin'); ?></p>
+            <?php else: ?>
+                <p class="acore-conn-note" style="margin:0 0 8px;">
+                    <?php _e('Showing', 'acore-wp-plugin'); ?> <span id="acore-conn-from"><?= (int) $from ?></span>-<span id="acore-conn-to"><?= (int) $to ?></span> <?php _e('of', 'acore-wp-plugin'); ?> <span id="acore-conn-total"><?= (int) $total ?></span> <?php _e('entries.', 'acore-wp-plugin'); ?>
+                    <?php if ($total > $perPage): ?>
+                        <?php _e('This only shows 50 at once; you can see more by pressing the button below.', 'acore-wp-plugin'); ?>
+                    <?php endif; ?>
+                </p>
+                <table class="wp-list-table widefat fixed striped acore-conn-table" style="max-width:860px;">
+                    <thead>
+                        <tr>
+                            <th><?php _e('IP Address', 'acore-wp-plugin'); ?></th>
+                            <th><?php _e('Country', 'acore-wp-plugin'); ?></th>
+                            <th><?php _e('Date / Time', 'acore-wp-plugin'); ?></th>
+                            <th><?php _e('Where', 'acore-wp-plugin'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody id="acore-conn-tbody">
+                        <?php foreach ($pageRows as $row): ?>
+                            <?php
+                                $ip      = $row['ip_address'] ?? ($row['ip'] ?? '');
+                                $country = $row['country'] ?? '';
+                                $when    = $row['login_at'] ?? ($row['timestamp'] ?? '');
+                                $src     = (($row['source'] ?? 'website') === 'ingame')
+                                            ? __('In-game', 'acore-wp-plugin')
+                                            : __('Website', 'acore-wp-plugin');
+                                $isCurrent = ($ip !== '' && $ip === $myIp);
+                            ?>
+                            <tr<?= $isCurrent ? ' class="acore-conn-current" title="' . esc_attr__('This matches your current IP', 'acore-wp-plugin') . '"' : '' ?>>
+                                <td><?= esc_html($ip) ?></td>
+                                <td><?= esc_html($country !== '' ? $country : 'Unknown') ?></td>
+                                <td><?= esc_html($when !== '' ? \ACore\Hooks\User\acore_format_connection_date($when) : '') ?></td>
+                                <td><?= esc_html($src) ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+                <?php if ($connPage < $maxPage): ?>
+                    <p style="margin-top:10px;">
+                        <button type="button" id="acore-conn-more" class="button" data-page="<?= (int) $connPage ?>"><?php _e('See more', 'acore-wp-plugin'); ?> &darr;</button>
+                    </p>
+                <?php endif; ?>
+            <?php endif; ?>
+
+        </div>
+    </div><!-- /postbox connections -->
+
+</div><!-- /wrap -->
+
+<script>
+(function(){
+    /* Password form toggle */
+    var btn    = document.getElementById('acore-set-password-btn');
+    var wrap   = document.getElementById('acore-password-form-wrap');
+    var cancel = document.getElementById('acore-cancel-password-btn');
+    if (btn)    btn.addEventListener('click',    function(){ wrap.style.display = ''; });
+    if (cancel) cancel.addEventListener('click', function(){ wrap.style.display = 'none'; });
+
+    /* Show/hide password toggles */
+    document.querySelectorAll('.acore-pw-toggle').forEach(function(toggle){
+        toggle.addEventListener('click', function(){
+            var input = this.closest('.acore-pw-field').querySelector('input');
+            var icon  = this.querySelector('.dashicons');
+            if (input.type === 'password') {
+                input.type = 'text';
+                icon.classList.replace('dashicons-visibility', 'dashicons-hidden');
+            } else {
+                input.type = 'password';
+                icon.classList.replace('dashicons-hidden', 'dashicons-visibility');
+            }
+        });
+    });
+
+    /* In-game 2FA removal */
+    var removeBtn = document.getElementById('acore-ingame-2fa-remove');
+    if (removeBtn) {
+        removeBtn.addEventListener('click', function(){
+            var code = document.getElementById('acore-ingame-2fa-code').value.trim();
+            var msg  = document.getElementById('acore-ingame-2fa-msg');
+            // A code is optional when the panel was already unlocked (e.g. via email 2FA);
+            // if one is typed it must be 6 digits.
+            if (code !== '' && !/^\d{6}$/.test(code)) {
+                msg.style.color = '#d63638';
+                msg.textContent = '<?php echo esc_js(__('Please enter a valid 6-digit code.', 'acore-wp-plugin')); ?>';
+                return;
+            }
+            removeBtn.disabled = true;
+            removeBtn.textContent = '<?php echo esc_js(__('Removing…', 'acore-wp-plugin')); ?>';
+            msg.textContent = '';
+            fetch('<?= esc_js($restBase) ?>', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-WP-Nonce':   '<?= esc_js($restNonce) ?>'
+                },
+                body: JSON.stringify({ token: code })
+            })
+            .then(function(r){ return r.json(); })
+            .then(function(data){
+                if (data.success) {
+                    msg.style.color   = '#00a32a';
+                    msg.textContent   = '<?php echo esc_js(__('In-game 2FA removed successfully. You can set it up again inside the game.', 'acore-wp-plugin')); ?>';
+                    // Refresh the page after short delay so the status badge updates
+                    setTimeout(function(){ window.location.reload(); }, 2200);
+                } else {
+                    throw data;
+                }
+            })
+            .catch(function(err){
+                msg.style.color   = '#d63638';
+                msg.textContent   = (err && (err.message || (err.data && err.data.message))) || '<?php echo esc_js(__('An error occurred. Please try again.', 'acore-wp-plugin')); ?>';
+                removeBtn.disabled = false;
+                removeBtn.textContent = '<?php echo esc_js(__('Remove In-game 2FA', 'acore-wp-plugin')); ?>';
+            });
+        });
+    }
+
+    /* Website 2FA gate: require a valid current TOTP code to reveal the panel */
+    var gateBtn = document.getElementById('acore-2fa-gate-btn');
+    if (gateBtn) {
+        var revealPanel = function(){
+            var gate  = document.getElementById('acore-2fa-gate');
+            var panel = document.getElementById('acore-2fa-panel');
+            if (gate)  gate.style.display  = 'none';
+            if (panel) panel.style.display = '';
+        };
+        var submitGate = function(){
+            var input = document.getElementById('acore-2fa-gate-code');
+            var msg   = document.getElementById('acore-2fa-gate-msg');
+            var code  = (input.value || '').trim();
+            if (!/^\d{6}$/.test(code)) {
+                msg.style.color = '#d63638';
+                msg.textContent = '<?php echo esc_js(__('Please enter a valid 6-digit code.', 'acore-wp-plugin')); ?>';
+                return;
+            }
+            gateBtn.disabled = true;
+            gateBtn.textContent = '<?php echo esc_js(__('Verifying…', 'acore-wp-plugin')); ?>';
+            msg.textContent = '';
+            fetch('<?= esc_js($verifyBase) ?>', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-WP-Nonce':   '<?= esc_js($restNonce) ?>'
+                },
+                body: JSON.stringify({ token: code })
+            })
+            .then(function(r){ return r.json(); })
+            .then(function(data){
+                if (data && data.success) {
+                    revealPanel();
+                } else {
+                    throw data;
+                }
+            })
+            .catch(function(err){
+                msg.style.color = '#d63638';
+                msg.textContent = (err && (err.message || (err.data && err.data.message))) || '<?php echo esc_js(__('Incorrect code. Please try again.', 'acore-wp-plugin')); ?>';
+                gateBtn.disabled = false;
+                gateBtn.textContent = '<?php echo esc_js(__('Unlock', 'acore-wp-plugin')); ?>';
+            });
+        };
+        gateBtn.addEventListener('click', submitGate);
+        var gateInput = document.getElementById('acore-2fa-gate-code');
+        if (gateInput) {
+            gateInput.addEventListener('keydown', function(e){
+                if (e.key === 'Enter') { e.preventDefault(); submitGate(); }
+            });
+        }
+    }
+
+    /* Website 2FA gate (email method): email a code, then unlock the panel */
+    var emailSend   = document.getElementById('acore-2fa-email-send');
+    var emailVerify = document.getElementById('acore-2fa-email-verify');
+    if (emailSend && emailVerify) {
+        var emsg = document.getElementById('acore-2fa-email-msg');
+        var revealEmailPanel = function(){
+            var g = document.getElementById('acore-2fa-gate-email');
+            var p = document.getElementById('acore-2fa-panel');
+            if (g) g.style.display = 'none';
+            if (p) p.style.display = '';
+        };
+        emailSend.addEventListener('click', function(){
+            emailSend.disabled = true;
+            emailSend.textContent = '<?php echo esc_js(__('Sending…', 'acore-wp-plugin')); ?>';
+            emsg.textContent = '';
+            fetch('<?= esc_js($emailRequestBase) ?>', {
+                method: 'POST',
+                headers: { 'X-WP-Nonce': '<?= esc_js($restNonce) ?>' }
+            })
+            .then(function(r){ return r.json(); })
+            .then(function(d){
+                if (d && d.success) {
+                    emsg.style.color = '#00a32a';
+                    emsg.textContent = '<?php echo esc_js(__('A code has been sent to your email.', 'acore-wp-plugin')); ?>';
+                } else { throw d; }
+            })
+            .catch(function(err){
+                emsg.style.color = '#d63638';
+                emsg.textContent = (err && (err.message || (err.data && err.data.message))) || '<?php echo esc_js(__('Could not send the code. Please try again.', 'acore-wp-plugin')); ?>';
+            })
+            .finally(function(){
+                emailSend.disabled = false;
+                emailSend.textContent = '<?php echo esc_js(__('Email me a code', 'acore-wp-plugin')); ?>';
+            });
+        });
+        var submitEmail = function(){
+            var code = (document.getElementById('acore-2fa-email-code').value || '').trim();
+            if (!/^\d{6}$/.test(code)) {
+                emsg.style.color = '#d63638';
+                emsg.textContent = '<?php echo esc_js(__('Please enter a valid 6-digit code.', 'acore-wp-plugin')); ?>';
+                return;
+            }
+            emailVerify.disabled = true;
+            emailVerify.textContent = '<?php echo esc_js(__('Verifying…', 'acore-wp-plugin')); ?>';
+            fetch('<?= esc_js($emailVerifyBase) ?>', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': '<?= esc_js($restNonce) ?>' },
+                body: JSON.stringify({ code: code })
+            })
+            .then(function(r){ return r.json(); })
+            .then(function(d){ if (d && d.success) { revealEmailPanel(); } else { throw d; } })
+            .catch(function(err){
+                emsg.style.color = '#d63638';
+                emsg.textContent = (err && (err.message || (err.data && err.data.message))) || '<?php echo esc_js(__('Incorrect code. Please try again.', 'acore-wp-plugin')); ?>';
+                emailVerify.disabled = false;
+                emailVerify.textContent = '<?php echo esc_js(__('Unlock', 'acore-wp-plugin')); ?>';
+            });
+        };
+        emailVerify.addEventListener('click', submitEmail);
+        var emailInput = document.getElementById('acore-2fa-email-code');
+        if (emailInput) {
+            emailInput.addEventListener('keydown', function(e){
+                if (e.key === 'Enter') { e.preventDefault(); submitEmail(); }
+            });
+        }
+    }
+})();
+
+/* Real-time 2FA removal detection: reload when state changes */
+(function(){
+    var statusUrl = '<?= esc_js($statusBase) ?>';
+    var nonce     = '<?= esc_js($restNonce) ?>';
+    var initial   = {
+        website: <?= $websiteAnyEnabled ? 'true' : 'false' ?>,
+        ingame:  <?= $ingame2faActive ? 'true' : 'false' ?>,
+        count:   <?= (int) count($adminLog) ?>
+    };
+    function check(){
+        fetch(statusUrl, { headers: { 'X-WP-Nonce': nonce }, credentials: 'same-origin' })
+            .then(function(r){ return r.ok ? r.json() : null; })
+            .then(function(d){
+                if (!d) return;
+                if (d.website_enabled !== initial.website ||
+                    d.ingame_enabled  !== initial.ingame  ||
+                    d.removal_count   !== initial.count) {
+                    window.location.reload();
+                }
+            })
+            .catch(function(){});
+    }
+    setInterval(check, 20000);
+})();
+
+/* Recent Connections: load the next 50 in place (no page reload) */
+(function(){
+    var btn = document.getElementById('acore-conn-more');
+    if (!btn) return;
+    var tbody = document.getElementById('acore-conn-tbody');
+    var toEl  = document.getElementById('acore-conn-to');
+    var base  = '<?= esc_js(rest_url(ACORE_SLUG . '/v1/connections')) ?>';
+    var nonce = '<?= esc_js(wp_create_nonce('wp_rest')) ?>';
+    btn.addEventListener('click', function(){
+        var next  = parseInt(btn.getAttribute('data-page'), 10) + 1;
+        var url   = base + '?page=' + next;
+        var label = btn.textContent;
+        btn.disabled = true; btn.textContent = 'Loading...';
+        fetch(url, { headers: { 'X-WP-Nonce': nonce } })
+            .then(function(r){ return r.json(); })
+            .then(function(d){
+                (d.rows || []).forEach(function(row){
+                    var tr = document.createElement('tr');
+                    if (row.current) { tr.className = 'acore-conn-current'; tr.title = 'This matches your current IP'; }
+                    ['ip','country','date','where'].forEach(function(k){
+                        var td = document.createElement('td');
+                        td.textContent = row[k] || '';
+                        tr.appendChild(td);
+                    });
+                    tbody.appendChild(tr);
+                });
+                if (toEl && typeof d.to !== 'undefined') toEl.textContent = d.to;
+                btn.setAttribute('data-page', d.page);
+                if (d.has_more) { btn.disabled = false; btn.textContent = label; }
+                else if (btn.parentNode) { btn.parentNode.removeChild(btn); }
+            })
+            .catch(function(){ btn.disabled = false; btn.textContent = label; });
+    });
+})();
+</script>

--- a/src/acore-wp-plugin/src/Components/UserPanel/UserController.php
+++ b/src/acore-wp-plugin/src/Components/UserPanel/UserController.php
@@ -9,13 +9,12 @@ use ACore\Components\UserPanel\UserView;
 class UserController {
 
     /**
-     *
      * @var UserView
      */
     private $view;
 
     public function __construct() {
-        $this->view = new UserView($this);
+        $this->view = new UserView();
     }
 
     public function showRafProgress() {
@@ -28,6 +27,7 @@ class UserController {
         $user = wp_get_current_user();
 
         if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+            check_admin_referer('acore_raf_recruit', 'acore_raf_nonce');
             $maxRecruitDatetime = (new \DateTime($user->get("user_registered")))->modify('+7days');
 
             if ($maxRecruitDatetime < (new \DateTime())) {
@@ -36,7 +36,10 @@ class UserController {
                 if (!isset($_POST["recruited"])) {
                     $errorMessages[] = "No recruiter value sent.";
                 } else {
-                    $recruiterCode = $_POST["recruited"];
+                    $recruiterCode = absint($_POST["recruited"]);
+                    if ($recruiterCode <= 0) {
+                        $errorMessages[] = "Invalid recruiter value sent.";
+                    }
                     $existingRecruiterId = $acServices->getUserNameByUserId($recruiterCode);
                     $newRecruitId = $acServices->getAcoreAccountId();
 
@@ -52,13 +55,10 @@ class UserController {
                         $userIp = $acServices->getAcoreAccountLastIp();
                         $activeUserIp = "";
                         if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ) {
-                            // check ip from share internet
                             $activeUserIp = $_SERVER['HTTP_CLIENT_IP'];
                         } elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-                            // to check ip is pass from proxy
                             $activeUserIp = $_SERVER['HTTP_X_FORWARDED_FOR'];
                         } else {
-                            // use default remote ip
                             $activeUserIp = $_SERVER['REMOTE_ADDR'];
                         }
 
@@ -136,28 +136,78 @@ class UserController {
     }
 
     public function showItemRestorationPage() {
-        if ($_SERVER["REQUEST_METHOD"] == "POST") {
-            $this->saveCharacterOrder();
-            ?>
-            <div class="updated"><p><strong>Character settings succesfully saved.</strong></p></div>
-            <?php
-        }
-
         $account = ACoreServices::I()->getAcoreAccountId();
         $conn = ACoreServices::I()->getCharacterEm()->getConnection();
         $queryResult = $conn->executeQuery(
-            "   SELECT `guid`, `name`, `order`
-                FROM `characters`
-                WHERE `characters`.`deleteDate` IS NULL AND `account` = $account
-                ORDER BY `order`, `guid`
-            "
+            "SELECT `guid`, `name`, `order`, `race`, `class`, `gender`, `level`
+             FROM `characters`
+             WHERE `deleteDate` IS NULL AND `account` = $account
+             ORDER BY `order`, `guid`"
         );
 
         echo $this->getView()->getItemRestorationRender($queryResult->fetchAllAssociative());
     }
 
+    public function showSecurityPage() {
+        $user = wp_get_current_user();
+
+        // Detect & log a user-initiated Website 2FA removal (records the user's IP).
+        if (function_exists('ACore\\Components\\ServerInfo\\acore_2fa_sync_self_removals')) {
+            \ACore\Components\ServerInfo\acore_2fa_sync_self_removals($user->ID);
+        }
+
+        $passwordMessage   = \ACore\Hooks\User\acore_pw_get_message($user->ID);
+        $passwordChangedAt = get_user_meta($user->ID, 'acore_password_changed_at', true);
+        $twoFaData         = $this->getTwoFaData($user);
+        $ingame2faActive   = $this->getIngame2faStatus();
+        $connections       = \ACore\Hooks\User\acore_get_login_history($user->ID, 500);
+
+        echo $this->getView()->getSecurityRender($connections, $passwordChangedAt, $twoFaData, $ingame2faActive, $passwordMessage);
+    }
+
+    private function getIngame2faStatus(): bool {
+        try {
+            $accId = ACoreServices::I()->getAcoreAccountId();
+            if (!$accId) return false;
+            $conn   = ACoreServices::I()->getAccountEm()->getConnection();
+            $result = $conn->executeQuery('SELECT totp_secret FROM account WHERE id = ?', [$accId]);
+            $row    = $result->fetchAssociative();
+            return $row && $row['totp_secret'] !== null;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    private function getTwoFaData(\WP_User $user) {
+        $active = class_exists('\WP2FA\WP2FA') || function_exists('wp2fa_get_enabled_providers_for_user');
+
+        if (!$active) {
+            return ['plugin_active' => false];
+        }
+
+        $primaryMethods  = get_user_meta($user->ID, 'wp_2fa_enabled_methods', true);
+        $backupMethods   = get_user_meta($user->ID, 'wp_2fa_backup_methods_enabled', true);
+        $totpKey         = get_user_meta($user->ID, 'wp_2fa_totp_key', true);
+        // TOTP is only considered enabled when the key exists AND it is actively
+        // listed as a primary method - WP2FA may leave the key in meta after removal.
+        $totpEnabled     = !empty($totpKey) && (
+                               (is_array($primaryMethods) && in_array('totp', $primaryMethods)) ||
+                               $primaryMethods === 'totp'
+                           );
+        $emailEnabled    = (is_array($primaryMethods) && in_array('email', $primaryMethods))
+                         || $primaryMethods === 'email';
+
+        return [
+            'plugin_active'   => true,
+            'primary_methods' => $primaryMethods ?: [],
+            'backup_methods'  => $backupMethods  ?: [],
+            'totp_enabled'    => $totpEnabled,
+            'email_enabled'   => $emailEnabled,
+            'setup_url'       => admin_url('profile.php?page=wp-2fa-setup'),
+        ];
+    }
+
     /**
-     *
      * @return UserView
      */
     public function getView() {
@@ -165,11 +215,10 @@ class UserController {
     }
 
     /**
-     *
      * @return UserModel
      */
     public function getModel() {
-        return $this->model;
+        return $this;
     }
 
 }

--- a/src/acore-wp-plugin/src/Components/UserPanel/UserMenu.php
+++ b/src/acore-wp-plugin/src/Components/UserPanel/UserMenu.php
@@ -26,9 +26,10 @@ class UserMenu
         return self::$instance;
     }
 
-    // action function for above hook
     function acore_user_menu()
     {
+        add_submenu_page('profile.php', 'Security', 'Security', 'read', ACORE_SLUG . '-security', array($this, 'security_page'));
+
         if (Opts::I()->eluna_recruit_a_friend == '1') {
             add_submenu_page('profile.php', 'Recruit a Friend', 'Recruit a Friend', 'read', ACORE_SLUG . '-eluna-raf-progress', array($this, 'eluna_raf_progress_page'));
         }
@@ -36,6 +37,13 @@ class UserMenu
         if (Opts::I()->acore_item_restoration == '1') {
             add_submenu_page('profile.php', 'Item Restoration', 'Item Restoration', 'read', ACORE_SLUG . '-item-restoration', array($this, 'item_restoration_page'));
         }
+    }
+
+    // action function for above hook
+    function security_page()
+    {
+        $ctrl = new UserController();
+        $ctrl->showSecurityPage();
     }
 
     // action function for above hook
@@ -48,6 +56,7 @@ class UserMenu
         }
     }
 
+    // action function for above hook
     function item_restoration_page()
     {
         $SettingsCtrl = new UserController();

--- a/src/acore-wp-plugin/src/Components/UserPanel/UserView.php
+++ b/src/acore-wp-plugin/src/Components/UserPanel/UserView.php
@@ -8,9 +8,17 @@ class UserView {
         extract([ $rafPersonalInfo, $rafPersonalProgress, $rafRecruitedInfo ]);
         ob_start();
         wp_enqueue_style('bootstrap-css', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css', array(), '5.1.3');
-        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.1');
+        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.5');
         wp_enqueue_script('bootstrap-js', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js', array(), '5.1.3');
         include(__DIR__ . '/Pages/RafProgressPage.php');
+        return ob_get_clean();
+    }
+
+    /* Page: Security */
+    function getSecurityRender($connections, $passwordChangedAt, $twoFaData, $ingame2faActive, $passwordMessage = null) {
+        ob_start();
+        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.5');
+        include(__DIR__ . '/Pages/SecurityPage.php');
         return ob_get_clean();
     }
 
@@ -19,9 +27,9 @@ class UserView {
         extract([$characters]);
         ob_start();
         wp_enqueue_style('bootstrap-css', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css', array(), '5.1.3');
-        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.1');
+        wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', array(), '0.5');
         wp_enqueue_script('bootstrap-js', '//cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js', array(), '5.1.3');
-        wp_enqueue_script('power-js', 'https://wow.zamimg.com/widgets/power.js', array());
+        wp_enqueue_script('power-js', 'https://wow.zamimg.com/widgets/power.js', array(), null, false);
         include(__DIR__ . '/Pages/ItemRestorationPage.php');
         return ob_get_clean();
     }

--- a/src/acore-wp-plugin/src/Hooks/User/ConnectionLogger.php
+++ b/src/acore-wp-plugin/src/Hooks/User/ConnectionLogger.php
@@ -1,0 +1,362 @@
+<?php
+
+namespace ACore\Hooks\User;
+
+add_action('init', __NAMESPACE__ . '\\acore_create_login_history_table');
+
+function acore_create_login_history_table() {
+    if (get_option('acore_login_history_db_version') === '2') {
+        return;
+    }
+
+    global $wpdb;
+    $table   = $wpdb->prefix . 'acore_login_history';
+    $collate = $wpdb->get_charset_collate();
+    $sql = "CREATE TABLE $table (
+        id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+        user_id bigint(20) UNSIGNED NOT NULL,
+        ip_address varchar(45) NOT NULL,
+        country varchar(10) NOT NULL DEFAULT 'Unknown',
+        source varchar(20) NOT NULL DEFAULT 'website',
+        login_at datetime NOT NULL,
+        PRIMARY KEY (id),
+        KEY user_id (user_id),
+        KEY login_at (login_at)
+    ) $collate;";
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta($sql);
+    update_option('acore_login_history_db_version', '2');
+}
+
+add_action('wp_login', __NAMESPACE__ . '\\acore_log_login', 10, 2);
+
+function acore_log_login($user_login, $user) {
+    if (get_option('acore_security_logging', '0') !== '1') {
+        return;
+    }
+
+    global $wpdb;
+
+    $ip = acore_resolve_client_ip();
+    $country = acore_lookup_country($ip);
+
+    $wpdb->insert(
+        $wpdb->prefix . 'acore_login_history',
+        [
+            'user_id'    => $user->ID,
+            'ip_address' => $ip,
+            'country'    => $country,
+            'source'     => 'website',
+            'login_at'   => current_time('mysql'),
+        ],
+        ['%d', '%s', '%s', '%s', '%s']
+    );
+
+    // Also capture the account's most recent in-game login IP.
+    acore_log_ingame_last_ip($user);
+}
+
+/**
+ * Record the player's last in-game login IP (from the game account table) as an
+ * "ingame" connection entry. Skipped if it already matches the latest one.
+ */
+function acore_log_ingame_last_ip($user) {
+    try {
+        $conn = \ACore\Manager\ACoreServices::I()->getAccountEm()->getConnection();
+        $row  = $conn->executeQuery(
+            'SELECT last_ip, last_login FROM account WHERE username = ?',
+            [strtoupper($user->user_login)]
+        )->fetchAssociative();
+    } catch (\Throwable $e) {
+        return;
+    }
+
+    if (!$row || empty($row['last_ip']) || $row['last_ip'] === '0.0.0.0') {
+        return;
+    }
+
+    $ip      = sanitize_text_field($row['last_ip']);
+    $loginAt = !empty($row['last_login']) ? $row['last_login'] : current_time('mysql');
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'acore_login_history';
+
+    // De-dup: skip if the latest ingame row already matches this IP + time.
+    $last = $wpdb->get_row($wpdb->prepare(
+        "SELECT ip_address, login_at FROM {$table} WHERE user_id = %d AND source = 'ingame' ORDER BY login_at DESC, id DESC LIMIT 1",
+        $user->ID
+    ), ARRAY_A);
+    if ($last && $last['ip_address'] === $ip && (string) $last['login_at'] === (string) $loginAt) {
+        return;
+    }
+
+    $wpdb->insert(
+        $table,
+        [
+            'user_id'    => $user->ID,
+            'ip_address' => $ip,
+            'country'    => acore_lookup_country($ip),
+            'source'     => 'ingame',
+            'login_at'   => $loginAt,
+        ],
+        ['%d', '%s', '%s', '%s', '%s']
+    );
+}
+
+function acore_resolve_client_ip() {
+    $remote = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+    $ip     = $remote;
+
+    // Honour forwarded headers only when REMOTE_ADDR is a configured trusted proxy.
+    if (get_option('acore_trust_proxy_headers', '0') === '1' && acore_ip_is_trusted_proxy($remote)) {
+        if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+            $parts     = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
+            $candidate = trim($parts[0]);
+            if (filter_var($candidate, FILTER_VALIDATE_IP)) {
+                $ip = $candidate;
+            }
+        } elseif (!empty($_SERVER['HTTP_CLIENT_IP']) && filter_var($_SERVER['HTTP_CLIENT_IP'], FILTER_VALIDATE_IP)) {
+            $ip = $_SERVER['HTTP_CLIENT_IP'];
+        }
+    }
+
+    $ip = trim((string) $ip);
+    if (!filter_var($ip, FILTER_VALIDATE_IP)) {
+        $ip = $remote;
+    }
+    return $ip;
+}
+
+function acore_ip_is_trusted_proxy($ip): bool {
+    $list = get_option('acore_trusted_proxies', '');
+    if (!is_string($list) || trim($list) === '') {
+        return false;
+    }
+    foreach (preg_split('/[\s,]+/', trim($list)) as $entry) {
+        if ($entry !== '' && acore_ip_in_cidr($ip, $entry)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function acore_ip_in_cidr($ip, $cidr): bool {
+    if (strpos($cidr, '/') === false) {
+        return $ip === $cidr;
+    }
+    list($subnet, $bits) = explode('/', $cidr, 2);
+    if (!ctype_digit((string) $bits)) {
+        return false;
+    }
+    $bits  = (int) $bits;
+    $ipBin = @inet_pton($ip);
+    $suBin = @inet_pton($subnet);
+    if ($ipBin === false || $suBin === false || strlen($ipBin) !== strlen($suBin)) {
+        return false;
+    }
+    if ($bits > strlen($ipBin) * 8) {
+        return false;
+    }
+    $bytes = intdiv($bits, 8);
+    $rem   = $bits % 8;
+    if ($bytes > 0 && substr($ipBin, 0, $bytes) !== substr($suBin, 0, $bytes)) {
+        return false;
+    }
+    if ($rem > 0) {
+        $mask = chr((0xff << (8 - $rem)) & 0xff);
+        if ((ord($ipBin[$bytes]) & ord($mask)) !== (ord($suBin[$bytes]) & ord($mask))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function acore_geoip_is_public_ip($ip): bool {
+    if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+        return false;
+    }
+    $long = ip2long($ip);
+    // RFC 6598 shared address space (100.64.0.0/10) is not covered by the flags.
+    if ($long !== false && ($long & 0xFFC00000) === (ip2long('100.64.0.0') & 0xFFC00000)) {
+        return false;
+    }
+    return true;
+}
+
+// Reuse a country already resolved for this IP in the history table (oldest wins).
+function acore_geoip_known_country($ip) {
+    global $wpdb;
+    $table = $wpdb->prefix . 'acore_login_history';
+    $c = $wpdb->get_var($wpdb->prepare(
+        "SELECT country FROM {$table} WHERE ip_address = %s AND country NOT IN ('Unknown', 'Local', '') ORDER BY login_at ASC, id ASC LIMIT 1",
+        $ip
+    ));
+    return $c ?: null;
+}
+
+function acore_geoip_is_blocked(): bool {
+    return (bool) get_transient('acore_geoip_blocked');
+}
+
+// Honour ip-api rate-limit headers: if X-Rl hits 0, stop calling for X-Ttl seconds.
+function acore_geoip_note_headers($response): void {
+    $rl  = wp_remote_retrieve_header($response, 'x-rl');
+    $ttl = wp_remote_retrieve_header($response, 'x-ttl');
+    if ($rl !== '' && (int) $rl <= 0) {
+        set_transient('acore_geoip_blocked', 1, max(1, (int) $ttl));
+    }
+}
+
+function acore_lookup_country($ip) {
+    if (!acore_geoip_is_public_ip($ip)) {
+        return 'Local';
+    }
+    if (get_option('acore_geoip_lookup', '0') !== '1') {
+        return 'Unknown';
+    }
+    // Already resolved this IP before? Reuse it - no API call.
+    $known = acore_geoip_known_country($ip);
+    if ($known) {
+        return $known;
+    }
+    // Inside an ip-api cooldown - defer to the backfill cron.
+    if (acore_geoip_is_blocked()) {
+        return 'Unknown';
+    }
+
+    $response = wp_remote_get("http://ip-api.com/json/{$ip}?fields=status,countryCode", [
+        'timeout' => 3,
+    ]);
+    if (is_wp_error($response)) {
+        return 'Unknown';
+    }
+    acore_geoip_note_headers($response);
+
+    $data = json_decode(wp_remote_retrieve_body($response), true);
+    if (isset($data['status'], $data['countryCode']) && $data['status'] === 'success') {
+        return $data['countryCode'];
+    }
+    return 'Unknown';
+}
+
+/* GeoIP backfill: resolve Unknown countries in the background, oldest first,
+   reusing known IPs and using the batch endpoint, within ip-api's limits. */
+add_filter('cron_schedules', function ($s) {
+    if (!isset($s['acore_5min'])) {
+        $s['acore_5min'] = ['interval' => 300, 'display' => 'Every 5 minutes (ACore)'];
+    }
+    return $s;
+});
+
+add_action('init', __NAMESPACE__ . '\\acore_geoip_schedule_backfill');
+function acore_geoip_schedule_backfill() {
+    if (!wp_next_scheduled('acore_geoip_backfill_event')) {
+        wp_schedule_event(time() + 300, 'acore_5min', 'acore_geoip_backfill_event');
+    }
+}
+
+add_action('acore_geoip_backfill_event', __NAMESPACE__ . '\\acore_geoip_backfill');
+function acore_geoip_backfill() {
+    if (get_option('acore_security_logging', '0') !== '1'
+        || get_option('acore_geoip_lookup', '0') !== '1'
+        || acore_geoip_is_blocked()) {
+        return;
+    }
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'acore_login_history';
+
+    $rows = $wpdb->get_results(
+        "SELECT ip_address, MIN(login_at) AS oldest
+         FROM {$table}
+         WHERE country = 'Unknown'
+         GROUP BY ip_address
+         ORDER BY oldest ASC
+         LIMIT 100",
+        ARRAY_A
+    );
+    if (!$rows) {
+        return;
+    }
+
+    $toQuery = [];
+    foreach ($rows as $r) {
+        $ip = $r['ip_address'];
+        if (!acore_geoip_is_public_ip($ip)) {
+            $wpdb->query($wpdb->prepare("UPDATE {$table} SET country = 'Local' WHERE ip_address = %s AND country = 'Unknown'", $ip));
+            continue;
+        }
+        $known = acore_geoip_known_country($ip);
+        if ($known) {
+            $wpdb->query($wpdb->prepare("UPDATE {$table} SET country = %s WHERE ip_address = %s AND country = 'Unknown'", $known, $ip));
+            continue;
+        }
+        $toQuery[] = $ip;
+    }
+    if (empty($toQuery)) {
+        return;
+    }
+
+    $toQuery  = array_slice(array_values(array_unique($toQuery)), 0, 100);
+    $response = wp_remote_post('http://ip-api.com/batch?fields=status,countryCode,query', [
+        'timeout' => 5,
+        'headers' => ['Content-Type' => 'application/json'],
+        'body'    => wp_json_encode(array_map(function ($ip) { return ['query' => $ip]; }, $toQuery)),
+    ]);
+    if (is_wp_error($response)) {
+        return;
+    }
+    acore_geoip_note_headers($response);
+
+    $results = json_decode(wp_remote_retrieve_body($response), true);
+    if (!is_array($results)) {
+        return;
+    }
+    foreach ($results as $res) {
+        if (empty($res['query'])) {
+            continue;
+        }
+        if (isset($res['status'], $res['countryCode']) && $res['status'] === 'success') {
+            $wpdb->query($wpdb->prepare(
+                "UPDATE {$table} SET country = %s WHERE ip_address = %s AND country = 'Unknown'",
+                $res['countryCode'],
+                $res['query']
+            ));
+        }
+    }
+}
+
+function acore_get_login_history($user_id, $limit = 50) {
+    global $wpdb;
+    $table = $wpdb->prefix . 'acore_login_history';
+    return $wpdb->get_results($wpdb->prepare(
+        "SELECT ip_address, country, login_at, source FROM $table WHERE user_id = %d ORDER BY login_at DESC LIMIT %d",
+        $user_id,
+        $limit
+    ), ARRAY_A);
+}
+
+function acore_format_connection_date($datetime_str) {
+    $dt = new \DateTime($datetime_str);
+    $day = (int) $dt->format('j');
+
+    if (in_array($day % 100, [11, 12, 13])) {
+        $suffix = 'th';
+    } else {
+        switch ($day % 10) {
+            case 1:  $suffix = 'st'; break;
+            case 2:  $suffix = 'nd'; break;
+            case 3:  $suffix = 'rd'; break;
+            default: $suffix = 'th';
+        }
+    }
+
+    return sprintf('%d%s of %s, %s at %s',
+        $day,
+        $suffix,
+        $dt->format('F'),
+        $dt->format('Y'),
+        $dt->format('H:i')
+    );
+}

--- a/src/acore-wp-plugin/src/Hooks/User/Include.php
+++ b/src/acore-wp-plugin/src/Hooks/User/Include.php
@@ -2,4 +2,6 @@
 
 namespace ACore\Hooks\User;
 
+require_once __DIR__ . "/ConnectionLogger.php";
+require_once __DIR__ . "/PasswordHandler.php";
 require_once __DIR__ . "/User.php";

--- a/src/acore-wp-plugin/src/Hooks/User/PasswordHandler.php
+++ b/src/acore-wp-plugin/src/Hooks/User/PasswordHandler.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace ACore\Hooks\User;
+
+use ACore\Manager\ACoreServices;
+use ACore\Manager\UserValidator;
+
+add_action('admin_init', __NAMESPACE__ . '\acore_process_security_password');
+
+function acore_process_security_password() {
+    if (!is_user_logged_in() || !isset($_POST['acore_change_password'])) {
+        return;
+    }
+
+    $user         = wp_get_current_user();
+    $security_url = admin_url('profile.php?page=' . ACORE_SLUG . '-security');
+
+    if (!wp_verify_nonce($_POST['acore_pw_nonce'] ?? '', 'acore_security_change_password')) {
+        acore_pw_set_message($user->ID, 'error', __('Security check failed.', 'acore-wp-plugin'));
+        wp_redirect($security_url);
+        exit;
+    }
+
+    if (\ACore\Components\ServerInfo\acore_website_2fa_enabled($user->ID)
+        && !get_transient(\ACore\Components\ServerInfo\acore_2fa_unlock_key($user->ID))) {
+        acore_pw_set_message($user->ID, 'error', __('Please verify your 2FA code before changing your password.', 'acore-wp-plugin'));
+        wp_redirect($security_url);
+        exit;
+    }
+
+    $oldPass     = isset($_POST['acore_old_pass'])     ? (string) wp_unslash($_POST['acore_old_pass'])     : '';
+    $newPass     = isset($_POST['acore_new_pass'])     ? (string) wp_unslash($_POST['acore_new_pass'])     : '';
+    $confirmPass = isset($_POST['acore_confirm_pass']) ? (string) wp_unslash($_POST['acore_confirm_pass']) : '';
+
+    if (!wp_check_password($oldPass, $user->user_pass, $user->ID)) {
+        acore_pw_set_message($user->ID, 'error', __('Current password is incorrect.', 'acore-wp-plugin'));
+        wp_redirect($security_url);
+        exit;
+    }
+
+    if ($newPass !== $confirmPass) {
+        acore_pw_set_message($user->ID, 'error', __('New passwords do not match.', 'acore-wp-plugin'));
+        wp_redirect($security_url);
+        exit;
+    }
+
+    if (wp_check_password($newPass, $user->user_pass, $user->ID)) {
+        acore_pw_set_message($user->ID, 'error', __('New password must be different from your current password.', 'acore-wp-plugin'));
+        wp_redirect($security_url);
+        exit;
+    }
+
+    $validation = UserValidator::validatePassword($newPass);
+    if ($validation !== true) {
+        acore_pw_set_message($user->ID, 'error', $validation);
+        wp_redirect($security_url);
+        exit;
+    }
+
+    if (acore_password_is_reused($user->ID, $newPass)) {
+        acore_pw_set_message($user->ID, 'error', __('This password has been used before. Please choose a different one.', 'acore-wp-plugin'));
+        wp_redirect($security_url);
+        exit;
+    }
+
+    $soapError = null;
+    try {
+        $soap   = ACoreServices::I()->getAccountSoap();
+        $result = $soap->setAccountPassword($user->user_login, $newPass);
+        if ($result instanceof \Exception) {
+            $soapError = $result->getMessage();
+        } elseif (!is_string($result) || stripos($result, 'changed') === false) {
+            $raw = is_string($result) ? trim($result) : '';
+            $soapError = $raw !== '' ? $raw : __('the game server rejected the change', 'acore-wp-plugin');
+        }
+    } catch (\Exception $e) {
+        $soapError = $e->getMessage();
+    }
+
+    if ($soapError !== null) {
+        error_log('[acore] in-game password sync failed (user ID ' . $user->ID . '): ' . $soapError);
+        acore_pw_set_message($user->ID, 'error', __('The in-game password could not be updated, so your website password was left unchanged. Please try again later.', 'acore-wp-plugin'));
+        wp_redirect($security_url);
+        exit;
+    }
+
+    acore_password_record_history($user->ID, $user->user_pass);
+
+    wp_set_password($newPass, $user->ID);
+    update_user_meta($user->ID, 'acore_password_changed_at', current_time('mysql'));
+
+    wp_set_current_user($user->ID);
+    wp_set_auth_cookie($user->ID, false);
+
+    acore_pw_set_message($user->ID, 'success', __('Password updated successfully.', 'acore-wp-plugin'));
+    wp_redirect($security_url);
+    exit;
+}
+
+function acore_pw_set_message($user_id, $type, $text) {
+    set_transient('acore_pw_msg_' . $user_id, ['type' => $type, 'text' => $text], 60);
+}
+
+function acore_pw_get_message($user_id) {
+    $msg = get_transient('acore_pw_msg_' . $user_id);
+    if ($msg) {
+        delete_transient('acore_pw_msg_' . $user_id);
+    }
+    return $msg ?: null;
+}
+
+function acore_password_is_reused($user_id, string $newPass): bool {
+    if (get_option('acore_allow_old_passwords', '0') === '1') {
+        return false;
+    }
+    $history = get_user_meta($user_id, 'acore_password_history', true) ?: [];
+    foreach ($history as $oldHash) {
+        if (wp_check_password($newPass, $oldHash, $user_id)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function acore_password_record_history($user_id, string $currentHash): void {
+    $history = get_user_meta($user_id, 'acore_password_history', true) ?: [];
+    array_unshift($history, $currentHash);
+    update_user_meta($user_id, 'acore_password_history', array_slice($history, 0, 10));
+}

--- a/src/acore-wp-plugin/src/Hooks/User/User.php
+++ b/src/acore-wp-plugin/src/Hooks/User/User.php
@@ -108,6 +108,7 @@ function user_profile_update($user_id, $old_user_data)
         if ($result instanceof \Exception) {
             die(sprintf(__("#2 ACore Error: Game server error: %s", 'acore-wp-plugin'), $result->getMessage()));
         }
+        update_user_meta($user_id, 'acore_password_changed_at', current_time('mysql'));
     }
 }
 
@@ -132,6 +133,7 @@ function user_password_reset($user, $new_pass)
     if ($result instanceof \Exception) {
         die(sprintf(__("#1 ACore Error: Game server error: %s", 'acore-wp-plugin'), $result->getMessage()));
     }
+    update_user_meta($user->ID, 'acore_password_changed_at', current_time('mysql'));
 }
 
 add_action('password_reset', __NAMESPACE__ . '\user_password_reset', 10, 2);
@@ -369,17 +371,63 @@ function extra_user_profile_fields($user)
 
     <table class="form-table">
         <tr>
-            <th><label for="acore-user-game-expansion"><?php _e("Expansion", 'acore-wp-plugin'); ?></label></th>
+            <th><label><?php _e("Expansion", 'acore-wp-plugin'); ?></label></th>
             <td>
-                <select id="acore-user-game-expansion" name="acore-user-game-expansion">
-                    <?php
-                    foreach (Common::EXPANSIONS as $key => $value) {
-                    ?><option value=<?= $value ?> <?= $userExpansion == $value ? "selected" : "" ?>><?= $key ?></option>
-                    <?php
+                <?php
+                $expansions = [
+                    Common::EXPANSION_CLASSIC => ['label' => 'Vanilla',               'color' => '#C39361'],
+                    Common::EXPANSION_TBC     => ['label' => 'The Burning Crusade',    'color' => '#62C907'],
+                    Common::EXPANSION_WOTLK   => ['label' => 'Wrath of the Lich King', 'color' => '#5DACEB'],
+                ];
+                ?>
+
+                <div class="acore-expansion-wrapper">
+                    <div class="acore-expansion-arrow" id="acore-exp-arrow"></div>
+                    <div class="acore-expansion-selector">
+                        <?php foreach ($expansions as $val => $exp): ?>
+                        <label class="acore-expansion-option<?= $userExpansion == $val ? ' is-selected' : '' ?>" style="--exp-color:<?= esc_attr($exp['color']) ?>;">
+                            <input type="radio" name="acore-user-game-expansion" value="<?= $val ?>" <?= $userExpansion == $val ? 'checked' : '' ?>>
+                            <span class="acore-expansion-label"><?= esc_html($exp['label']) ?></span>
+                        </label>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+
+                <p class="acore-expansion-warning">
+                    &#9888; <strong><?php _e('Warning:', 'acore-wp-plugin'); ?></strong>
+                    <?php _e('This will restrict your account to the selected content. For example, selecting Vanilla means you cannot access TBC zones, create Draenei or Blood Elves, make Death Knights, or travel to Northrend.', 'acore-wp-plugin'); ?>
+                </p>
+
+                <script>
+                (function() {
+                    var arrow = document.getElementById('acore-exp-arrow');
+
+                    function updateArrow() {
+                        var selected = document.querySelector('.acore-expansion-option.is-selected');
+                        var wrapper  = document.querySelector('.acore-expansion-wrapper');
+                        if (!selected || !wrapper || !arrow) return;
+
+                        var wRect = wrapper.getBoundingClientRect();
+                        var sRect = selected.getBoundingClientRect();
+                        var centerX = sRect.left + sRect.width / 2 - wRect.left;
+                        var color   = selected.style.getPropertyValue('--exp-color') || '#646970';
+
+                        arrow.style.left           = centerX + 'px';
+                        arrow.style.borderTopColor = color;
                     }
-                    ?>
-                </select>
-                <span class="description"><?php _e("Game expansion to enable", 'acore-wp-plugin'); ?></span>
+
+                    document.querySelectorAll('.acore-expansion-option input[type="radio"]').forEach(function(radio) {
+                        radio.addEventListener('change', function() {
+                            document.querySelectorAll('.acore-expansion-option').forEach(function(o) { o.classList.remove('is-selected'); });
+                            this.closest('.acore-expansion-option').classList.add('is-selected');
+                            updateArrow();
+                        });
+                    });
+
+                    // Position on load
+                    updateArrow();
+                })();
+                </script>
             </td>
         </tr>
         <?php
@@ -440,11 +488,15 @@ function save_extra_user_profile_fields($user_id)
     }
 
 
-    $expansion = $_POST['acore-user-game-expansion'];
+    if (!isset($_POST['acore-user-game-expansion'])) {
+        return;
+    }
 
-    if (!$expansion || !in_array($expansion, Common::EXPANSIONS)) {
+    $rawExpansion = wp_unslash($_POST['acore-user-game-expansion']);
+    $expansion    = is_numeric($rawExpansion) ? (int) $rawExpansion : null;
+
+    if ($expansion === null || !in_array($expansion, Common::EXPANSIONS, true)) {
         $expansion = Common::EXPANSION_WOTLK;
-        // throw new \Exception(__("Invalid Expansion!", "acore-wp-plugin"));
     }
 
     if ($expansion != $gameUser->getExpansion()) {
@@ -564,3 +616,213 @@ function login_checks()
 }
 
 add_action('login_enqueue_scripts', __NAMESPACE__ . '\login_checks');
+
+add_action('show_user_profile', __NAMESPACE__ . '\acore_profile_2fa_removal_warning');
+add_action('edit_user_profile', __NAMESPACE__ . '\acore_profile_2fa_removal_warning');
+
+function acore_profile_2fa_removal_warning($user) {
+    // admin_notices already shows this at the top of plain profile.php — avoid duplicate
+    global $pagenow;
+    if ($pagenow === 'profile.php' && !isset($_GET['page'])) return;
+
+    $adminLog        = get_user_meta($user->ID, 'acore_2fa_admin_log', true);
+    $adminLog        = is_array($adminLog) ? $adminLog : [];
+    $lastWebRemoval  = null;
+    $lastGameRemoval = null;
+    foreach ($adminLog as $entry) {
+        if ($entry['type'] === 'website') $lastWebRemoval  = $entry;
+        if ($entry['type'] === 'ingame')  $lastGameRemoval = $entry;
+    }
+
+    // Check current 2FA state - website
+    $webActive = \ACore\Components\ServerInfo\acore_website_2fa_enabled($user->ID);
+
+    // Check current 2FA state - ingame
+    $gameActive = false;
+    try {
+        $conn   = \ACore\Manager\ACoreServices::I()->getAccountEm()->getConnection();
+        $result = $conn->executeQuery('SELECT totp_secret FROM account WHERE username = ?', [strtoupper($user->user_login)]);
+        $row    = $result->fetchAssociative();
+        $gameActive = $row && $row['totp_secret'] !== null;
+    } catch (\Exception $e) {
+        // DB unavailable - skip
+    }
+
+    $showWebWarning  = $lastWebRemoval  && !$webActive;
+    $showGameWarning = $lastGameRemoval && !$gameActive;
+
+    if (!$showWebWarning && !$showGameWarning) return;
+
+    $security_url = admin_url('profile.php?page=' . ACORE_SLUG . '-security');
+    ?>
+    <div class="notice notice-warning" style="margin:16px 0; padding:10px 14px;">
+        <p style="margin:0 0 4px; font-weight:600;">
+            <?php _e('Your 2FA was manually removed by a staff member.', 'acore-wp-plugin'); ?>
+        </p>
+        <?php if ($showWebWarning): ?>
+            <p style="margin:4px 0 0; font-size:13px;">
+                - <?php printf(
+                    __('Website 2FA removed on %1$s by %2$s.', 'acore-wp-plugin'),
+                    '<strong>' . esc_html(wp_date('jS \o\f F, Y \a\t H:i', $lastWebRemoval['timestamp'])) . '</strong>',
+                    (($lastWebRemoval['by'] ?? 'admin') === 'self'
+                        ? '<strong>' . esc_html__('you', 'acore-wp-plugin') . '</strong>'
+                        : '<strong>' . esc_html($lastWebRemoval['staff'] ?? __('a staff member', 'acore-wp-plugin')) . '</strong>')
+                ); ?>
+            </p>
+        <?php endif; ?>
+        <?php if ($showGameWarning): ?>
+            <p style="margin:4px 0 0; font-size:13px;">
+                - <?php printf(
+                    __('In-game 2FA removed on %1$s by %2$s.', 'acore-wp-plugin'),
+                    '<strong>' . esc_html(wp_date('jS \o\f F, Y \a\t H:i', $lastGameRemoval['timestamp'])) . '</strong>',
+                    '<strong>' . esc_html($lastGameRemoval['staff']) . '</strong>'
+                ); ?>
+            </p>
+        <?php endif; ?>
+        <p style="margin:6px 0 0; font-size:13px;">
+            <a href="<?= esc_url($security_url) ?>"><?php _e('Go to Security page to re-enable &rarr;', 'acore-wp-plugin'); ?></a>
+        </p>
+    </div>
+    <?php
+}
+
+// Remove WP2FA plugin blocks from the standard WordPress profile page only.
+// They belong in the dedicated Security sub-page — skip removal when there.
+add_action('admin_init', function () {
+    global $pagenow;
+    if ($pagenow !== 'profile.php' && $pagenow !== 'user-edit.php') return;
+    $page = isset($_GET['page']) ? $_GET['page'] : '';
+    if ($page === ACORE_SLUG . '-security') return; // Security sub-page: leave hooks intact
+
+    global $wp_filter;
+    foreach (['show_user_profile', 'edit_user_profile'] as $hook) {
+        if (empty($wp_filter[$hook])) continue;
+        foreach ($wp_filter[$hook]->callbacks as $priority => $callbacks) {
+            foreach ($callbacks as $key => $cb) {
+                $func = $cb['function'];
+                $id   = '';
+                if (is_array($func) && is_object($func[0]))     $id = get_class($func[0]);
+                elseif (is_array($func) && is_string($func[0])) $id = $func[0];
+                elseif (is_string($func))                        $id = $func;
+                if ($id && (
+                    stripos($id, 'WP2FA')      !== false ||
+                    stripos($id, 'wp_2fa')     !== false ||
+                    stripos($id, 'Two_Factor') !== false
+                )) {
+                    unset($wp_filter[$hook]->callbacks[$priority][$key]);
+                }
+            }
+        }
+    }
+}, 99);
+
+// Hide "New Password" fields on the standard profile page
+add_filter('show_password_fields', function ($show) {
+    global $pagenow;
+    if ($pagenow === 'profile.php') return false;
+    return $show;
+});
+
+// 2FA removal warning at the TOP of Profile > Profile (admin_notices)
+add_action('admin_notices', function () {
+    global $pagenow;
+    if ($pagenow !== 'profile.php') return;
+    if (isset($_GET['page'])) return; // sub-pages (Security, etc.) — skip
+
+    $user = wp_get_current_user();
+    $adminLog        = get_user_meta($user->ID, 'acore_2fa_admin_log', true);
+    $adminLog        = is_array($adminLog) ? $adminLog : [];
+    $lastWebRemoval  = null;
+    $lastGameRemoval = null;
+    foreach ($adminLog as $entry) {
+        if ($entry['type'] === 'website') $lastWebRemoval  = $entry;
+        if ($entry['type'] === 'ingame')  $lastGameRemoval = $entry;
+    }
+
+    $webActive = \ACore\Components\ServerInfo\acore_website_2fa_enabled($user->ID);
+    $gameActive = false;
+    try {
+        $conn   = \ACore\Manager\ACoreServices::I()->getAccountEm()->getConnection();
+        $result = $conn->executeQuery('SELECT totp_secret FROM account WHERE username = ?', [strtoupper($user->user_login)]);
+        $row    = $result->fetchAssociative();
+        $gameActive = $row && $row['totp_secret'] !== null;
+    } catch (\Exception $e) {}
+
+    $showWebWarning  = $lastWebRemoval  && !$webActive;
+    $showGameWarning = $lastGameRemoval && !$gameActive;
+    if (!$showWebWarning && !$showGameWarning) return;
+
+    $security_url = admin_url('profile.php?page=' . ACORE_SLUG . '-security');
+    ?>
+    <div class="notice notice-warning" style="padding:10px 14px;">
+        <p style="margin:0 0 4px; font-weight:600;"><?php _e('Your 2FA was manually removed by a staff member.', 'acore-wp-plugin'); ?></p>
+        <?php if ($showWebWarning): ?>
+            <p style="margin:4px 0 0; font-size:13px;">- <?php printf(
+                __('Website 2FA removed on %1$s by %2$s. Please re-enable it for account security.', 'acore-wp-plugin'),
+                '<strong>' . esc_html(wp_date('jS \o\f F, Y \a\t H:i', $lastWebRemoval['timestamp'])) . '</strong>',
+                '<strong>' . esc_html($lastWebRemoval['staff']) . '</strong>'
+            ); ?></p>
+        <?php endif; ?>
+        <?php if ($showGameWarning): ?>
+            <p style="margin:4px 0 0; font-size:13px;">- <?php printf(
+                __('In-game 2FA removed on %1$s by %2$s. Please re-enable it for account security.', 'acore-wp-plugin'),
+                '<strong>' . esc_html(wp_date('jS \o\f F, Y \a\t H:i', $lastGameRemoval['timestamp'])) . '</strong>',
+                '<strong>' . esc_html($lastGameRemoval['staff']) . '</strong>'
+            ); ?></p>
+        <?php endif; ?>
+        <p style="margin:6px 0 0; font-size:13px;"><a href="<?= esc_url($security_url) ?>"><?php _e('Go to Security page to re-enable &rarr;', 'acore-wp-plugin'); ?></a></p>
+    </div>
+    <?php
+});
+
+add_action('show_user_profile', __NAMESPACE__ . '\acore_profile_recent_connections');
+
+function acore_profile_recent_connections($user) {
+    $security_url = admin_url('profile.php?page=' . ACORE_SLUG . '-security');
+    $myIp = acore_resolve_client_ip();
+
+    $rows = acore_get_login_history($user->ID, 10);
+    $rows = array_slice($rows, 0, 10);
+    ?>
+    <h2 class="acore-conn-heading"><span><?php _e('Recent Connections', 'acore-wp-plugin'); ?></span><span class="acore-conn-myip"><?php _e('Your IPv4:', 'acore-wp-plugin'); ?> <?= esc_html($myIp) ?></span></h2>
+    <?php if (empty($rows)): ?>
+        <p><?php _e('No connections recorded yet.', 'acore-wp-plugin'); ?></p>
+    <?php else: ?>
+        <p class="acore-conn-note" style="margin:0 0 8px;">
+            <?php _e('This only shows the latest 10 logins.', 'acore-wp-plugin'); ?>
+            <?php printf(esc_html__('Showing %d entries.', 'acore-wp-plugin'), count($rows)); ?>
+        </p>
+        <table class="wp-list-table widefat fixed striped acore-conn-table" style="max-width:860px;">
+            <thead>
+                <tr>
+                    <th><?php _e('IP Address', 'acore-wp-plugin'); ?></th>
+                    <th><?php _e('Country', 'acore-wp-plugin'); ?></th>
+                    <th><?php _e('Date / Time', 'acore-wp-plugin'); ?></th>
+                    <th><?php _e('Where', 'acore-wp-plugin'); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($rows as $row):
+                    $ip      = $row['ip_address'] ?? ($row['ip'] ?? '');
+                    $country = $row['country'] ?? '';
+                    $when    = $row['login_at'] ?? ($row['timestamp'] ?? '');
+                    $src     = (($row['source'] ?? 'website') === 'ingame')
+                                ? __('In-game', 'acore-wp-plugin')
+                                : __('Website', 'acore-wp-plugin');
+                    $cur     = ($ip !== '' && $ip === $myIp);
+                ?>
+                    <tr<?= $cur ? ' class="acore-conn-current" title="' . esc_attr__('This matches your current IP', 'acore-wp-plugin') . '"' : '' ?>>
+                        <td><?= esc_html($ip) ?></td>
+                        <td><?= esc_html($country !== '' ? $country : 'Unknown') ?></td>
+                        <td><?= esc_html($when !== '' ? acore_format_connection_date($when) : '') ?></td>
+                        <td><?= esc_html($src) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+        <p style="margin-top:10px;">
+            <a href="<?= esc_url($security_url) ?>" class="button"><?php _e('See more', 'acore-wp-plugin'); ?> &rarr;</a>
+        </p>
+    <?php endif; ?>
+    <?php
+}

--- a/src/acore-wp-plugin/src/Hooks/Various/DarkMode.php
+++ b/src/acore-wp-plugin/src/Hooks/Various/DarkMode.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace ACore\Hooks\Various;
+
+add_action('admin_bar_menu', __NAMESPACE__ . '\acore_dark_mode_bar_node', 999);
+
+function acore_dark_mode_bar_node($wp_admin_bar) {
+    if (!is_user_logged_in() || !is_admin()) {
+        return;
+    }
+
+    $is_dark = get_user_meta(get_current_user_id(), 'acore_dark_mode', true) === '1';
+
+    $wp_admin_bar->add_node([
+        'id'     => 'acore-dark-mode',
+        'parent' => 'top-secondary',
+        'title'  => '<span id="acore-dm-icon">' . ($is_dark ? '&#9728;' : '&#9790;') . '</span>',
+        'href'   => '#',
+        'meta'   => ['title' => $is_dark ? 'Switch to light mode' : 'Switch to dark mode'],
+    ]);
+}
+
+add_filter('admin_body_class', __NAMESPACE__ . '\acore_dark_mode_body_class');
+
+function acore_dark_mode_body_class($classes) {
+    if (get_user_meta(get_current_user_id(), 'acore_dark_mode', true) === '1') {
+        $classes .= ' acore-dark-mode';
+    }
+    return $classes;
+}
+
+add_action('admin_enqueue_scripts', __NAMESPACE__ . '\acore_dark_mode_enqueue');
+
+function acore_dark_mode_enqueue() {
+    wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', [], '3.0');
+    wp_enqueue_style('acore-dark-mode', ACORE_URL_PLG . 'web/assets/css/dark-mode.css', ['acore-css'], '3.7');
+    // Central light/dark theme layer (edit colours here). Loaded last so it wins.
+    wp_enqueue_style('acore-theme', ACORE_URL_PLG . 'web/assets/css/theme.css', ['acore-dark-mode'], '3.7');
+
+    $nonce = wp_create_nonce('acore_dark_mode');
+    wp_add_inline_script('jquery-core', acore_dark_mode_js($nonce));
+}
+
+/*
+ * Late inline <style> injected at end of admin head (priority 9999) so it always
+ * wins the cascade over WordPress color-scheme CSS and any plugin stylesheets,
+ * even those that use !important.
+ */
+add_action('admin_head', __NAMESPACE__ . '\acore_dark_mode_late_styles', 9999);
+
+function acore_dark_mode_late_styles() {
+    // Always: WP2FA modal size - applies in both light and dark mode
+    ?>
+    <style id="acore-wp2fa-modal-size">
+        .wp2fa-modal .modal__container {
+            max-width: 900px !important;
+            width: 85vw !important;
+            min-height: 480px !important;
+            font-size: 16px !important;
+            padding: 40px !important;
+        }
+        .wp2fa-modal .modal__content { font-size: 16px !important; }
+        .wp2fa-modal .modal__content * { font-size: inherit !important; }
+    </style>
+    <?php
+
+    if (get_user_meta(get_current_user_id(), 'acore_dark_mode', true) !== '1') {
+        return;
+    }
+    ?>
+    <style id="acore-dark-mode-late">
+
+        /* character list rows - handled by dark-mode.css; only overrides needed here */
+        .acore-dark-mode .acore-char-meta img.race-icon  { border-color: color-mix(in srgb, var(--faction-color, rgba(255,255,255,0.15)) 70%, transparent) !important; }
+        .acore-dark-mode .acore-char-meta img.class-icon { border-color: color-mix(in srgb, var(--cls-dark, rgba(255,255,255,0.15)) 70%, transparent) !important; }
+        .acore-dark-mode #acore-characters-mail .acore-char-row.active { background: #21262d !important; border-top-color: var(--faction-color, #58a6ff) !important; border-right-color: var(--faction-color, #58a6ff) !important; border-bottom-color: var(--faction-color, #58a6ff) !important; border-top-width: 3px !important; border-right-width: 3px !important; border-bottom-width: 3px !important; }
+
+        /* Bootstrap card */
+        .acore-dark-mode .card,
+        .acore-dark-mode .card-body,
+        .acore-dark-mode .card-header { background-color: #161b22 !important; border-color: #30363d !important; color: #c9d1d9 !important; }
+
+        /* mail entries - border color set by JS inline (faction/class), only bg overridden */
+        .acore-dark-mode .mail-entry { background: #161b22 !important; }
+        .acore-dark-mode .mail-recipient,
+        .acore-dark-mode .mail-items { background: #0d1117 !important; }
+        .acore-dark-mode .mail-entry *,
+        .acore-dark-mode .mail-recipient *,
+        .acore-dark-mode .mail-meta { color: #c9d1d9 !important; }
+
+        /* myCred / points widgets */
+        .acore-dark-mode [id^="mycred"],
+        .acore-dark-mode [class*="mycred"] { background: #161b22 !important; border-color: #30363d !important; color: #c9d1d9 !important; }
+        .acore-dark-mode [id^="mycred"] *,
+        .acore-dark-mode [class*="mycred"] * { color: #c9d1d9 !important; }
+
+        /* Bootstrap form-select */
+        .acore-dark-mode .form-select { background-color: #0d1117 !important; border-color: #30363d !important; color: #c9d1d9 !important; }
+
+        /* hr */
+        .acore-dark-mode hr { border-color: #30363d !important; }
+
+    </style>
+    <?php
+}
+
+add_action('wp_ajax_acore_toggle_dark_mode', __NAMESPACE__ . '\acore_ajax_toggle_dark_mode');
+
+function acore_ajax_toggle_dark_mode() {
+    check_ajax_referer('acore_dark_mode', 'nonce');
+    $user_id = get_current_user_id();
+    $new     = get_user_meta($user_id, 'acore_dark_mode', true) === '1' ? '0' : '1';
+    update_user_meta($user_id, 'acore_dark_mode', $new);
+    wp_send_json_success(['dark' => $new === '1']);
+}
+
+function acore_dark_mode_js(string $nonce): string {
+    return <<<JS
+(function($){
+    var nonce = '{$nonce}';
+    $(document).on('click', '#wp-admin-bar-acore-dark-mode > a', function(e){
+        e.preventDefault();
+        $.post(ajaxurl, { action: 'acore_toggle_dark_mode', nonce: nonce }, function(res){
+            if (!res.success) return;
+            var dark = res.data.dark;
+            $('body').toggleClass('acore-dark-mode', dark);
+            $('#acore-dm-icon').html(dark ? '&#9728;' : '&#9790;');
+            $('#wp-admin-bar-acore-dark-mode > a').attr('title', dark ? 'Switch to light mode' : 'Switch to dark mode');
+        });
+    });
+})(jQuery);
+JS;
+}
+
+/*
+ * The WP 2FA setup wizard (profile.php?page=wp-2fa-setup) renders a sealed
+ * full-page template that only prints its own stylesheets. It exposes
+ * `wp_2fa_setup_page_scripts` inside its <head>; we use it to inject theme.css
+ * (whose body.wp2fa-setup rules are dark) only when the user has dark mode on.
+ */
+add_action('wp_2fa_setup_page_scripts', __NAMESPACE__ . '\acore_dark_mode_wizard_css');
+
+function acore_dark_mode_wizard_css() {
+    if (get_user_meta(get_current_user_id(), 'acore_dark_mode', true) !== '1') {
+        return;
+    }
+    echo '<link rel="stylesheet" id="acore-theme-wizard-css" media="all" href="'
+        . esc_url(ACORE_URL_PLG . 'web/assets/css/theme.css') . '?ver=3.7" />' . "\n";
+}

--- a/src/acore-wp-plugin/src/Hooks/Various/tgmplugin_activator.php
+++ b/src/acore-wp-plugin/src/Hooks/Various/tgmplugin_activator.php
@@ -39,7 +39,13 @@ add_action( 'tgmpa_register', function () {
 			'slug'      => 'mycred',
 			'required'  => true,
 		),
-		
+		array(
+			'name'             => 'WP 2FA',
+			'slug'             => 'wp-2fa',
+			'required'         => true,
+			'force_activation' => true,
+		),
+
 		// <snip />
 	);
 

--- a/src/acore-wp-plugin/src/Manager/ACoreServices.php
+++ b/src/acore-wp-plugin/src/Manager/ACoreServices.php
@@ -402,16 +402,44 @@ class ACoreServices
     }
 
     public function getRestorableItemsByCharacter($character) {
-        $query = "SELECT `Id`, `ItemEntry`
-            FROM `recovery_item`
-            WHERE `Guid` = ?
-        ";
+        $conn  = $this->getCharacterEm()->getConnection();
+        $accId = $this->getAcoreAccountId();
+
+        if (!is_numeric($character) || !$accId) {
+            throw new \InvalidArgumentException('Invalid character');
+        }
+
+        $ownership = $conn->prepare(
+            "SELECT 1 FROM `characters` WHERE `guid` = ? AND `account` = ? AND `deleteDate` IS NULL"
+        );
+        $ownership->bindValue(1, intval($character));
+        $ownership->bindValue(2, intval($accId));
+        if (!$ownership->executeQuery()->fetchOne()) {
+            throw new \InvalidArgumentException('Character not found');
+        }
+
+        $stmt = $conn->prepare(
+            "SELECT `Id`, `ItemEntry`, `Count`, `DeleteDate`
+             FROM `recovery_item`
+             WHERE `Guid` = ?
+             ORDER BY `DeleteDate` DESC"
+        );
+        $stmt->bindValue(1, intval($character));
+        return $stmt->executeQuery()->fetchAllAssociative();
+    }
+
+    public function currentAccountOwnsCharacterName($name): bool {
+        $accId = $this->getAcoreAccountId();
+        if (!$accId || $name === '' || $name === null) {
+            return false;
+        }
         $conn = $this->getCharacterEm()->getConnection();
-        $stmt = $conn->prepare($query);
-        $stmt->bindValue(1, $character);
-        $stmt->executeQuery();
-        $res = $stmt->executeQuery();
-        return $res->fetchAllAssociative();
+        $stmt = $conn->prepare(
+            "SELECT 1 FROM `characters` WHERE `name` = ? AND `account` = ? AND `deleteDate` IS NULL"
+        );
+        $stmt->bindValue(1, $name);
+        $stmt->bindValue(2, intval($accId));
+        return (bool) $stmt->executeQuery()->fetchOne();
     }
 
     /** 

--- a/src/acore-wp-plugin/src/Manager/Opts.php
+++ b/src/acore-wp-plugin/src/Manager/Opts.php
@@ -47,6 +47,9 @@ class Opts {
         [81, 360], // else, 360 days
     ];
     public $acore_name_unlock_allowed_banned_names_table="";
+    public $acore_security_logging="0";
+    public $acore_allow_old_passwords="0";
+    public $acore_geoip_lookup="0";
 
     public function __get($property) {
         if (property_exists($this, $property)) {

--- a/src/acore-wp-plugin/src/Manager/Soap/SmartstoneService.php
+++ b/src/acore-wp-plugin/src/Manager/Soap/SmartstoneService.php
@@ -18,7 +18,7 @@ class SmartstoneService {
      * other service types will be rejected by the mod's HandleSmartStoneUnlockAccountCommand.
      *
      * $accountName is expected to come from a WordPress user_login (sanitize_user
-     * restricts these to alphanumerics, dot, hyphen, underscore, at — no spaces),
+     * restricts these to alphanumerics, dot, hyphen, underscore, at - no spaces),
      * but we still cast the numeric args at the boundary as belt-and-braces.
      */
     public function addAccountVanity($accountName, $category, $vanityID) {

--- a/src/acore-wp-plugin/src/Utils/AcoreCharColors.php
+++ b/src/acore-wp-plugin/src/Utils/AcoreCharColors.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace ACore\Utils;
+
+class AcoreCharColors {
+
+    /**
+     * WotLK class colors.
+     * light = adjusted for visibility on white backgrounds (Rogue/Priest darkened)
+     * dark  = original WoW colors, bright enough for dark backgrounds
+     */
+    const CLASS_NAMES = [
+        1  => 'Warrior',
+        2  => 'Paladin',
+        3  => 'Hunter',
+        4  => 'Rogue',
+        5  => 'Priest',
+        6  => 'Death Knight',
+        7  => 'Shaman',
+        8  => 'Mage',
+        9  => 'Warlock',
+        11 => 'Druid',
+    ];
+
+    const CLASS_COLORS = [
+        1  => ['light' => '#C69B6D', 'dark' => '#C69B6D'], // Warrior
+        2  => ['light' => '#F48CBA', 'dark' => '#F48CBA'], // Paladin
+        3  => ['light' => '#AAD372', 'dark' => '#AAD372'], // Hunter
+        4  => ['light' => '#C8A800', 'dark' => '#FFF468'], // Rogue (yellow → darkened for light bg)
+        5  => ['light' => '#909090', 'dark' => '#E0E0E0'], // Priest (white → grey for light bg)
+        6  => ['light' => '#C41E3A', 'dark' => '#FF3355'], // Death Knight
+        7  => ['light' => '#0070DD', 'dark' => '#3399FF'], // Shaman
+        8  => ['light' => '#3FC7EB', 'dark' => '#3FC7EB'], // Mage
+        9  => ['light' => '#8788EE', 'dark' => '#9A9BFF'], // Warlock
+        11 => ['light' => '#FF7C0A', 'dark' => '#FF7C0A'], // Druid
+    ];
+
+    const FALLBACK_LIGHT = '#646970';
+    const FALLBACK_DARK  = '#8b949e';
+
+    const RACE_NAMES = [
+        1  => 'Human',
+        2  => 'Orc',
+        3  => 'Dwarf',
+        4  => 'Night Elf',
+        5  => 'Undead',
+        6  => 'Tauren',
+        7  => 'Gnome',
+        8  => 'Troll',
+        10 => 'Blood Elf',
+        11 => 'Draenei',
+    ];
+
+    /** Maps race ID → faction. */
+    const RACE_FACTION = [
+        1  => 'alliance', // Human
+        2  => 'horde',    // Orc
+        3  => 'alliance', // Dwarf
+        4  => 'alliance', // Night Elf
+        5  => 'horde',    // Undead
+        6  => 'horde',    // Tauren
+        7  => 'alliance', // Gnome
+        8  => 'horde',    // Troll
+        10 => 'horde',    // Blood Elf
+        11 => 'alliance', // Draenei
+    ];
+
+    public static function getClassName(int $classId): string {
+        return self::CLASS_NAMES[$classId] ?? 'Unknown';
+    }
+
+    public static function getRaceName(int $raceId): string {
+        return self::RACE_NAMES[$raceId] ?? 'Unknown';
+    }
+
+    public static function getFaction(int $raceId): string {
+        return self::RACE_FACTION[$raceId] ?? 'unknown';
+    }
+
+    /**
+     * Returns inline style string for a character row.
+     * Uses CSS custom properties so dark-mode.css can override via color-mix.
+     */
+    public static function rowStyle(int $classId, int $raceId): string {
+        $cls     = self::CLASS_COLORS[$classId]  ?? ['light' => self::FALLBACK_LIGHT, 'dark' => self::FALLBACK_DARK];
+        $faction = self::RACE_FACTION[$raceId]   ?? 'unknown';
+        $fLight  = $faction === 'alliance' ? '#3FACF4' : '#FF653D';
+        $fDark   = $faction === 'alliance' ? '#3FACF4' : '#FF653D';
+        return sprintf(
+            '--cls-light:%s; --cls-dark:%s; --faction-color:%s; border-top:2px solid %s; border-right:2px solid %s; border-bottom:2px solid %s; border-left:4px solid %s;',
+            $cls['light'], $cls['dark'], $fLight,
+            $fLight, $fLight, $fLight, $cls['light']
+        );
+    }
+
+    /** Returns the expansion slug for a level, used as data-exp attribute. */
+    public static function expansionSlug(int $level): string {
+        if ($level <= 60) return 'vanilla';
+        if ($level <= 70) return 'tbc';
+        return 'wrath';
+    }
+
+    /** Returns the expansion label for a level, used as title attribute. */
+    public static function expansionLabel(int $level): string {
+        if ($level <= 60) return 'Classic';
+        if ($level <= 70) return 'The Burning Crusade';
+        return 'Wrath of the Lich King';
+    }
+}

--- a/src/acore-wp-plugin/src/boot.php
+++ b/src/acore-wp-plugin/src/boot.php
@@ -3,6 +3,7 @@
 define('FS_METHOD', 'direct');
 
 require_once ACORE_PATH_PLG . 'src/Utils/AcoreUtils.php';
+require_once ACORE_PATH_PLG . 'src/Utils/AcoreCharColors.php';
 
 require_once ACORE_PATH_PLG . 'src/Deps/class-tgm-plugin-activation.php';
 
@@ -18,6 +19,7 @@ require_once ACORE_PATH_PLG . 'src/Components/UserPanel/UserMenu.php';
 require_once ACORE_PATH_PLG . 'src/Hooks/Subscriptions/sync_subscription.php';
 
 require_once ACORE_PATH_PLG . 'src/Hooks/Various/tgmplugin_activator.php';
+require_once ACORE_PATH_PLG . 'src/Hooks/Various/DarkMode.php';
 
 require_once ACORE_PATH_PLG . 'src/Hooks/User/Include.php';
 

--- a/src/acore-wp-plugin/web/assets/css/dark-mode.css
+++ b/src/acore-wp-plugin/web/assets/css/dark-mode.css
@@ -1,0 +1,706 @@
+/*
+Acore dark mode overrides
+*/
+
+/* ============================================================
+   Profile page & sub-tabs — dark mode appearance overrides only
+   (layout/spacing lives in main.css and loads for all modes)
+   ============================================================ */
+
+body.acore-dark-mode.profile-php #wpbody-content h2,
+body.acore-dark-mode.profile-php #wpbody-content h3 {
+    border-bottom-color: #30363d;
+}
+
+/* dark mode tweaks for security page */
+body.acore-dark-mode #acore-security-page .postbox {
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* Fix hardcoded dark thead in item restoration — let dark mode handle it */
+body.acore-dark-mode #acore-item-restoration-page .table thead {
+    background: #1d2327;
+    color: #fff;
+}
+
+/* --- Item Restoration dark mode --- */
+body.acore-dark-mode #acore-item-restoration-page .table {
+    color: #c9d1d9;
+    border-color: #30363d;
+    --bs-table-bg: transparent;
+    --bs-table-striped-bg: transparent;
+    --bs-table-border-color: #30363d;
+}
+
+body.acore-dark-mode #acore-item-restoration-page .table > :not(caption) > * > * {
+    background-color: #161b22 !important;
+    border-bottom-color: #30363d !important;
+    color: #c9d1d9 !important;
+    --bs-table-bg: #161b22;
+    --bs-table-color: #c9d1d9;
+}
+
+body.acore-dark-mode #acore-item-restoration-page .table thead tr th {
+    background: #21262d !important;
+    color: #e6edf3 !important;
+    border-color: #30363d !important;
+}
+
+body.acore-dark-mode #acore-item-restoration-page .table tbody td,
+body.acore-dark-mode #acore-item-restoration-page .table tbody th {
+    background: #161b22 !important;
+    color: #c9d1d9 !important;
+    border-color: #30363d !important;
+}
+
+/* alert-info (no items / info messages) */
+body.acore-dark-mode #acore-item-restoration-page .alert-info {
+    background-color: #1a2f1a !important;
+    border-color: #2d6a2d !important;
+    color: #56d364 !important;
+}
+
+/* active character row */
+body.acore-dark-mode #acore-characters-item-restore .acore-char-row.active {
+    background: #21262d !important;
+    border-top-color: var(--faction-color, #58a6ff) !important;
+    border-right-color: var(--faction-color, #58a6ff) !important;
+    border-bottom-color: var(--faction-color, #58a6ff) !important;
+    border-top-width: 3px !important;
+    border-right-width: 3px !important;
+    border-bottom-width: 3px !important;
+}
+
+/* ============================================================ */
+
+/* --- expansion selector (profile page) --- */
+.acore-expansion-wrapper {
+    position: relative;
+    padding-top: 14px;
+    margin-bottom: 8px;
+}
+
+.acore-expansion-arrow {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 0;
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+    border-top: 10px solid #646970;
+    transform: translateX(-50%);
+    transition: left 0.15s ease;
+}
+
+.acore-expansion-selector {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.acore-expansion-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 14px 7px 10px;
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-left: 4px solid var(--exp-color, #646970);
+    border-radius: 2px;
+    cursor: pointer;
+}
+
+.acore-expansion-option input[type="radio"] {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+}
+
+.acore-expansion-option .acore-expansion-label {
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--exp-color, #646970);
+}
+
+.acore-expansion-option.is-selected {
+    box-shadow: 0 0 0 2px var(--exp-color, #646970);
+}
+
+.acore-expansion-option:hover {
+    background: #f6f7f7;
+}
+
+.acore-expansion-warning {
+    color: #8a6d3b;
+    background: #fcf8e3;
+    border-left: 4px solid #f0ad4e;
+    border-radius: 2px;
+    padding: 8px 12px;
+    margin: 0;
+    font-size: 12px;
+    max-width: 520px;
+}
+
+/* dark mode */
+body.acore-dark-mode .acore-expansion-option {
+    background: #1c2128 !important;
+    border-top-color: #30363d !important;
+    border-right-color: #30363d !important;
+    border-bottom-color: #30363d !important;
+    border-left-color: var(--exp-color, #8b949e) !important;
+}
+
+body.acore-dark-mode .acore-expansion-option:hover {
+    background: #262d36 !important;
+}
+
+body.acore-dark-mode .acore-expansion-option.is-selected {
+    box-shadow: 0 0 0 2px var(--exp-color, #8b949e) !important;
+}
+
+body.acore-dark-mode .acore-expansion-warning {
+    background: #2d2208 !important;
+    border-left-color: #f0ad4e !important;
+    color: #d4a843 !important;
+}
+
+/* --- admin bar toggle icon --- */
+#wp-admin-bar-acore-dark-mode > .ab-item {
+    padding: 0 8px !important;
+    cursor: pointer;
+    display: flex !important;
+    align-items: center;
+    height: 32px;
+}
+
+#wp-admin-bar-acore-dark-mode > .ab-item #acore-dm-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    font-size: 18px;
+    line-height: 1;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 5px;
+    padding: 2px;
+}
+
+/* --- Bootstrap 5 CSS variable overrides (must come before class rules) --- */
+body.acore-dark-mode {
+    --bs-body-bg: #0d1117;
+    --bs-body-color: #c9d1d9;
+    --bs-card-bg: #161b22;
+    --bs-card-border-color: #30363d;
+    --bs-card-cap-bg: #0d1117;
+    --bs-border-color: #30363d;
+    --bs-secondary-color: #8b949e;
+    --bs-link-color: #58a6ff;
+    --bs-link-hover-color: #79c0ff;
+    --bs-list-group-bg: #161b22;
+    --bs-list-group-border-color: #30363d;
+    --bs-list-group-color: #c9d1d9;
+}
+
+/* --- base --- */
+body.acore-dark-mode,
+body.acore-dark-mode #wpwrap {
+    background: #0d1117;
+    color: #c9d1d9;
+}
+
+body.acore-dark-mode #wpcontent,
+body.acore-dark-mode #wpfooter {
+    background: #0d1117;
+}
+
+body.acore-dark-mode #wpbody-content {
+    background: #0d1117;
+}
+
+/* --- headings & text --- */
+body.acore-dark-mode h1,
+body.acore-dark-mode h2,
+body.acore-dark-mode h3,
+body.acore-dark-mode h4,
+body.acore-dark-mode h5,
+body.acore-dark-mode p,
+body.acore-dark-mode label,
+body.acore-dark-mode span,
+body.acore-dark-mode li {
+    color: #c9d1d9;
+}
+
+body.acore-dark-mode .description,
+body.acore-dark-mode .text-muted {
+    color: #8b949e !important;
+}
+
+body.acore-dark-mode hr {
+    border-color: #30363d;
+}
+
+/* --- postboxes (WP core) --- */
+body.acore-dark-mode .postbox,
+body.acore-dark-mode #poststuff .postbox {
+    background: #161b22;
+    border-color: #30363d;
+}
+
+body.acore-dark-mode .postbox-header {
+    background: #161b22;
+    border-bottom-color: #30363d;
+}
+
+body.acore-dark-mode .postbox-header h2,
+body.acore-dark-mode .postbox-header .hndle {
+    color: #c9d1d9;
+}
+
+body.acore-dark-mode .postbox .inside {
+    color: #c9d1d9;
+}
+
+/* --- Bootstrap card --- */
+body.acore-dark-mode .card {
+    background-color: #161b22 !important;
+    border-color: #30363d !important;
+    color: #c9d1d9 !important;
+}
+
+body.acore-dark-mode .card-body {
+    background-color: #161b22 !important;
+    color: #c9d1d9 !important;
+}
+
+body.acore-dark-mode .card-header {
+    background-color: #0d1117 !important;
+    border-bottom-color: #30363d !important;
+    color: #c9d1d9 !important;
+}
+
+body.acore-dark-mode .card-title {
+    color: #c9d1d9 !important;
+}
+
+/* --- Character list rows --- */
+body.acore-dark-mode .acore-char-row {
+    background: #1c2128 !important;
+    /* faction color for top/right/bottom, dimmed for dark mode */
+    border-top-color: color-mix(in srgb, var(--faction-color, #30363d) 55%, #0d1117) !important;
+    border-right-color: color-mix(in srgb, var(--faction-color, #30363d) 55%, #0d1117) !important;
+    border-bottom-color: color-mix(in srgb, var(--faction-color, #30363d) 55%, #0d1117) !important;
+    border-left-color: var(--cls-dark, #8b949e) !important;
+}
+
+body.acore-dark-mode .acore-char-pos {
+    color: #e6edf3 !important;
+    background: rgba(255, 255, 255, 0.12) !important;
+}
+
+body.acore-dark-mode .acore-char-name {
+    color: #c9d1d9 !important;
+}
+
+body.acore-dark-mode .acore-char-meta {
+    color: #8b949e !important;
+}
+
+body.acore-dark-mode .acore-char-row:hover {
+    background: #262d36 !important;
+}
+
+body.acore-dark-mode #acore-characters-mail .acore-char-row.active {
+    background: #21262d !important;
+    border-top-color: var(--faction-color, #58a6ff) !important;
+    border-right-color: var(--faction-color, #58a6ff) !important;
+    border-bottom-color: var(--faction-color, #58a6ff) !important;
+    border-top-width: 3px !important;
+    border-right-width: 3px !important;
+    border-bottom-width: 3px !important;
+}
+
+/* --- Bootstrap form-select --- */
+body.acore-dark-mode .form-select {
+    background-color: #0d1117 !important;
+    border-color: #30363d !important;
+    color: #c9d1d9 !important;
+}
+
+body.acore-dark-mode .form-select:focus {
+    border-color: #58a6ff !important;
+    box-shadow: 0 0 0 0.2rem rgba(88, 166, 255, 0.25) !important;
+}
+
+/* --- form elements --- */
+body.acore-dark-mode input[type="text"],
+body.acore-dark-mode input[type="password"],
+body.acore-dark-mode input[type="email"],
+body.acore-dark-mode input[type="number"],
+body.acore-dark-mode input[type="search"],
+body.acore-dark-mode input[type="url"],
+body.acore-dark-mode select,
+body.acore-dark-mode textarea {
+    background-color: #0d1117;
+    border-color: #30363d;
+    color: #c9d1d9;
+    box-shadow: none;
+}
+
+body.acore-dark-mode input[type="text"]:focus,
+body.acore-dark-mode input[type="password"]:focus,
+body.acore-dark-mode select:focus,
+body.acore-dark-mode textarea:focus {
+    border-color: #58a6ff;
+    box-shadow: 0 0 0 1px #58a6ff;
+    outline: none;
+}
+
+body.acore-dark-mode .form-table th {
+    color: #8b949e;
+}
+
+body.acore-dark-mode .form-table td {
+    color: #c9d1d9;
+}
+
+/* --- mail entries — border color comes from JS inline (faction/class), only override bg --- */
+body.acore-dark-mode .mail-entry {
+    background: #161b22 !important;
+    color: #c9d1d9 !important;
+}
+
+body.acore-dark-mode .mail-recipient,
+body.acore-dark-mode .mail-items {
+    background: #0d1117 !important;
+    color: #c9d1d9 !important;
+}
+
+body.acore-dark-mode .mail-header,
+body.acore-dark-mode .mail-meta,
+body.acore-dark-mode .mail-subject,
+body.acore-dark-mode .mail-money,
+body.acore-dark-mode .recipient-name {
+    color: #c9d1d9 !important;
+}
+
+/* --- tables --- */
+body.acore-dark-mode .widefat,
+body.acore-dark-mode .wp-list-table {
+    background: #161b22;
+    border-color: #30363d;
+    color: #c9d1d9;
+}
+
+body.acore-dark-mode .widefat thead th,
+body.acore-dark-mode .widefat tfoot th,
+body.acore-dark-mode .wp-list-table thead th {
+    background: #0d1117;
+    color: #8b949e;
+    border-bottom-color: #30363d;
+}
+
+body.acore-dark-mode .widefat td,
+body.acore-dark-mode .widefat th,
+body.acore-dark-mode .wp-list-table td {
+    color: #c9d1d9;
+    border-bottom-color: #21262d;
+}
+
+body.acore-dark-mode .striped > tbody > :nth-child(odd) > td,
+body.acore-dark-mode .striped > tbody > :nth-child(odd) > th,
+body.acore-dark-mode .alternate {
+    background: #1c2128;
+}
+
+/* --- buttons --- */
+body.acore-dark-mode .button,
+body.acore-dark-mode .button-secondary {
+    background: #21262d;
+    border-color: #30363d;
+    color: #c9d1d9;
+    text-shadow: none;
+    box-shadow: none;
+}
+
+body.acore-dark-mode .button:hover,
+body.acore-dark-mode .button-secondary:hover {
+    background: #30363d;
+    border-color: #8b949e;
+    color: #f0f6fc;
+}
+
+body.acore-dark-mode .button-primary {
+    background: #1f6feb;
+    border-color: #1f6feb;
+    color: #fff;
+    text-shadow: none;
+    box-shadow: none;
+}
+
+body.acore-dark-mode .button-primary:hover {
+    background: #388bfd;
+    border-color: #388bfd;
+}
+
+body.acore-dark-mode .button-primary:disabled,
+body.acore-dark-mode .button-primary[disabled] {
+    background: #1f6feb;
+    opacity: 0.5;
+}
+
+/* --- Bootstrap buttons --- */
+body.acore-dark-mode .btn-primary {
+    background-color: #1f6feb !important;
+    border-color: #1f6feb !important;
+}
+
+body.acore-dark-mode .btn-primary:hover {
+    background-color: #388bfd !important;
+    border-color: #388bfd !important;
+}
+
+body.acore-dark-mode .btn-outline-secondary,
+body.acore-dark-mode .btn-secondary {
+    background-color: #21262d !important;
+    border-color: #30363d !important;
+    color: #c9d1d9 !important;
+}
+
+/* --- notices --- */
+body.acore-dark-mode .notice,
+body.acore-dark-mode div.updated,
+body.acore-dark-mode div.error {
+    background: #161b22;
+    border-color: #30363d;
+    color: #c9d1d9;
+}
+
+body.acore-dark-mode .notice-success,
+body.acore-dark-mode .updated {
+    border-left-color: #3fb950;
+}
+
+body.acore-dark-mode .notice-error,
+body.acore-dark-mode div.error {
+    border-left-color: #f85149;
+}
+
+body.acore-dark-mode .notice-warning {
+    border-left-color: #d29922;
+}
+
+body.acore-dark-mode .notice p,
+body.acore-dark-mode div.updated p,
+body.acore-dark-mode div.error p {
+    color: #c9d1d9;
+}
+
+/* --- links --- */
+body.acore-dark-mode a {
+    color: #58a6ff;
+}
+
+body.acore-dark-mode a:hover {
+    color: #79c0ff;
+}
+
+/* --- footer --- */
+body.acore-dark-mode #wpfooter {
+    border-top-color: #30363d;
+    color: #8b949e;
+}
+
+body.acore-dark-mode #wpfooter a {
+    color: #58a6ff;
+}
+
+/* --- myCred widgets --- */
+body.acore-dark-mode [id^="mycred"],
+body.acore-dark-mode [class^="mycred"],
+body.acore-dark-mode .mycred-wrap,
+body.acore-dark-mode .mycred-widget {
+    background: #161b22 !important;
+    border-color: #30363d !important;
+    color: #c9d1d9 !important;
+}
+
+body.acore-dark-mode .mycred-history,
+body.acore-dark-mode .mycred-history *,
+body.acore-dark-mode #mycred-log-wrap,
+body.acore-dark-mode #mycred-log-wrap * {
+    background: #161b22 !important;
+    color: #c9d1d9 !important;
+    border-color: #30363d !important;
+}
+
+/* WP profile page balance box */
+body.acore-dark-mode #mycred-user-balance,
+body.acore-dark-mode .user-profile-mycred,
+body.acore-dark-mode td.mycred-field,
+body.acore-dark-mode th.mycred-field {
+    color: #c9d1d9 !important;
+}
+
+/* --- Scroll of Resurrection page --- */
+body.acore-dark-mode .acore-rscroll .card {
+    background: #161b22;
+    border-color: #30363d;
+    color: #c9d1d9;
+}
+
+body.acore-dark-mode .acore-rscroll .card-body {
+    color: #c9d1d9;
+}
+
+body.acore-dark-mode .acore-rscroll h5 {
+    color: #e6edf3;
+}
+
+body.acore-dark-mode .acore-rscroll hr {
+    border-color: #30363d;
+    opacity: 1;
+}
+
+body.acore-dark-mode .acore-rscroll .table {
+    color: #c9d1d9;
+    border-color: #30363d;
+    --bs-table-bg: transparent;
+    --bs-table-striped-bg: transparent;
+    --bs-table-border-color: #30363d;
+}
+
+body.acore-dark-mode .acore-rscroll .table > :not(caption) > * > * {
+    background-color: transparent;
+    border-bottom-color: #30363d;
+    color: #ffffff;
+}
+
+/* Row label column (th inside tbody) */
+body.acore-dark-mode .acore-rscroll .table tbody th {
+    background: #21262d !important;
+    color: #e6edf3 !important;
+    font-weight: 600;
+    border-color: #30363d !important;
+}
+
+body.acore-dark-mode .acore-rscroll .table tbody td {
+    background: #161b22 !important;
+    color: #ffffff !important;
+    border-color: #30363d !important;
+}
+
+/* thead row (Player Commands table) */
+body.acore-dark-mode .acore-rscroll .table thead tr th,
+body.acore-dark-mode .acore-rscroll .table-light thead tr th {
+    background: #21262d !important;
+    color: #e6edf3 !important;
+    border-color: #30363d !important;
+}
+
+body.acore-dark-mode .acore-rscroll code {
+    background: #0d1117;
+    color: #f85149;
+    border: 1px solid #30363d;
+    padding: 1px 5px;
+    border-radius: 3px;
+}
+
+body.acore-dark-mode .acore-rscroll .text-muted {
+    color: #8b949e !important;
+}
+
+body.acore-dark-mode .acore-rscroll strong {
+    color: #818cf8;
+}
+
+body.acore-dark-mode .acore-rscroll ol,
+body.acore-dark-mode .acore-rscroll p,
+body.acore-dark-mode .acore-rscroll li {
+    color: #ffffff;
+}
+
+body.acore-dark-mode .acore-rscroll .text-muted {
+    color: #b0b8c4 !important;
+}
+
+/* Force white text on all badges */
+body.acore-dark-mode .acore-rscroll .badge {
+    color: #ffffff !important;
+}
+
+/* Warning badge: yellow is unreadable with white text — shift to solid orange */
+body.acore-dark-mode .acore-rscroll .badge.bg-warning {
+    background-color: #c27400 !important;
+}
+
+/* --- Expansion level badge — dark mode --- */
+body.acore-dark-mode .acore-level { color: #8b949e; }
+body.acore-dark-mode .acore-level[data-exp="vanilla"] { background: rgba(195, 147, 97, 0.18); border-color: #C39361; color: #c9d1d9; }
+body.acore-dark-mode .acore-level[data-exp="tbc"]     { background: rgba(98, 201, 7, 0.18);   border-color: #62C907; color: #c9d1d9; }
+body.acore-dark-mode .acore-level[data-exp="wrath"]   { background: rgba(93, 172, 235, 0.18); border-color: #5DACEB; color: #c9d1d9; }
+
+/* --- Mail Return dark mode --- */
+body.acore-dark-mode #mail-return-heading {
+    color: #e6edf3 !important;
+}
+
+body.acore-dark-mode #mail-return-items .mail-entry {
+    background: #161b22;
+    border-color: #30363d;
+}
+
+body.acore-dark-mode #mail-return-items .mail-header {
+    background: #0d1117;
+    border-bottom-color: #30363d;
+}
+
+body.acore-dark-mode #mail-return-items .mail-recipient,
+body.acore-dark-mode #mail-return-items .mail-subject,
+body.acore-dark-mode #mail-return-items .mail-meta {
+    color: #c9d1d9;
+}
+
+body.acore-dark-mode #mail-return-items .mail-to-label,
+body.acore-dark-mode #mail-return-items .mail-subject-label {
+    color: #8b949e;
+}
+
+body.acore-dark-mode #mail-return-items .mail-items-grid {
+    background: #0d1117;
+    border-top-color: #30363d;
+}
+
+body.acore-dark-mode #mail-return-items .mail-item-slot {
+    background: #161b22;
+}
+
+body.acore-dark-mode #mail-return-items .mail-item-slot a {
+    color: #c9d1d9;
+}
+
+body.acore-dark-mode #mail-return-items .mail-cod-label {
+    color: #8b949e;
+}
+
+body.acore-dark-mode .mail-return-button {
+    background: #21262d !important;
+    border-color: #30363d !important;
+    color: #c9d1d9 !important;
+}
+
+body.acore-dark-mode .mail-return-button:hover {
+    background: #30363d !important;
+    color: #e6edf3 !important;
+}
+
+body.acore-dark-mode #mail-return-empty {
+    color: #8b949e;
+}

--- a/src/acore-wp-plugin/web/assets/css/main.css
+++ b/src/acore-wp-plugin/web/assets/css/main.css
@@ -17,62 +17,187 @@ body {
     background-color: var(--bs-teal) !important;
 }
 
-/* start char-order */
-#acore-characters-order .menu-item-handle {
+/* start acore-char-list — shared character row layout */
+.acore-char-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
 }
 
-#acore-characters-order .item-type {
-    padding: 0px;
-    margin-top: 5px;
+.acore-char-list li {
+    margin-bottom: 4px;
 }
 
-#acore-characters-order .item-type img {
-    display: inline-block;
-    vertical-align: middle;
-    height: 32px;
-    transform: translateZ(0); /* prevent blurry image on chrome */
-}
-
-#acore-characters-order input {
+.acore-char-list input[type="hidden"],
+.acore-char-list input[name="characterorder[]"] {
     display: none;
 }
 
-/* end char order */
-
-/* start char-unstuck */
-#acore-characters-unstuck .menu-item-handle {
-    cursor: default;
+button.acore-char-row {
+    font: inherit;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+    -webkit-appearance: none;
+    appearance: none;
 }
 
-.unstuck-button {
-    background-size: cover;
-    border: none;
-    color: transparent;
+/* Clicking a card/button shouldn't select its text (name, number, label). */
+button.acore-char-row,
+button.acore-char-row *,
+.item-restore-card,
+.item-restore-card * {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+/* Tools setting labels: informational only (no control activation), help cursor. */
+.acore-help-label {
+    cursor: help;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.acore-char-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    min-height: 46px;
+    padding: 6px 12px;
+    box-sizing: border-box;
+    background: #fff;
+    /* top/right/bottom use faction color; left uses class color */
+    border-top: 2px solid var(--faction-color, #dcdcde);
+    border-right: 2px solid var(--faction-color, #dcdcde);
+    border-bottom: 2px solid var(--faction-color, #dcdcde);
+    border-left: 4px solid var(--cls-light, #646970);
+    border-radius: 2px;
+}
+
+.acore-char-pos {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 22px;
+    font-size: 11px;
+    font-weight: 700;
+    color: #3c434a;
+    background: rgba(0, 0, 0, 0.10);
+    border-radius: 4px;
+    margin-right: 8px;
+    flex-shrink: 0;
+}
+
+.acore-char-name {
+    flex: 1;
+    font-weight: 500;
+}
+
+.acore-char-meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: #646970;
+}
+
+.acore-level {
+    display: inline-block;
+    text-transform: uppercase;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    min-width: 52px;
+    text-align: center;
+    /* badge shape */
+    padding: 2px 6px;
+    border-radius: 3px;
+    border: 1.5px solid currentcolor;
+    color: #50575e;
+}
+
+/* Expansion badge: filled background + matching border */
+.acore-level[data-exp="vanilla"] {
+    background: rgba(195, 147, 97, 0.12);
+    border-color: #C39361;
+    color: #50575e;
+}
+.acore-level[data-exp="tbc"] {
+    background: rgba(98, 201, 7, 0.12);
+    border-color: #62C907;
+    color: #50575e;
+}
+.acore-level[data-exp="wrath"] {
+    background: rgba(93, 172, 235, 0.12);
+    border-color: #5DACEB;
+    color: #50575e;
+}
+
+.acore-char-meta img {
+    display: inline-block;
+    vertical-align: middle;
+    height: 32px;
+    width: 32px;
+    transform: translateZ(0); /* prevent blurry image on chrome */
+    border: 3px solid rgba(0, 0, 0, 0.12);
+    border-radius: 4px;
+}
+
+/* Race icon: faction color border */
+.acore-char-meta img.race-icon {
+    border-color: var(--faction-color, rgba(0, 0, 0, 0.12));
+}
+
+/* Class icon: class color border */
+.acore-char-meta img.class-icon {
+    border-color: var(--cls-light, rgba(0, 0, 0, 0.12));
+}
+
+/* sortable drag cursor on order list */
+#acore-characters-order .acore-char-row {
+    cursor: grab;
+}
+
+#acore-characters-order .acore-char-row:active {
+    cursor: grabbing;
+}
+
+/* click cursor on mail return */
+#acore-characters-mail .acore-char-row {
     cursor: pointer;
 }
 
+#acore-characters-mail .acore-char-row.active {
+    background: #f0f4f8;
+    /* thicken faction borders to signal selection; border-left (class color) unchanged */
+    border-top-width: 3px;
+    border-right-width: 3px;
+    border-bottom-width: 3px;
+}
+/* end acore-char-list */
+
+/* start unstuck button */
+.unstuck-button {
+    border: none;
+    color: transparent;
+    cursor: pointer;
+    background-color: transparent;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
+    padding: 0;
+}
+
 .unstuck-button:disabled {
-    opacity: 0.5; /* Adjust the opacity for disabled state */
+    opacity: 0.5;
     cursor: not-allowed;
 }
-
-#acore-characters-unstuck .item-type {
-    padding: 0px;
-    margin-top: 5px;
-}
-
-#acore-characters-unstuck .item-type img {
-    display: inline-block;
-    vertical-align: middle;
-    height: 32px;
-    transform: translateZ(0); /* prevent blurry image on chrome */
-}
-
-#acore-characters-unstuck input {
-    display: none;
-}
-
-/* end char unstuck */
+/* end unstuck button */
 
 
 /* start raf progress view */
@@ -206,66 +331,198 @@ body {
 
 /* end raf progress view */
 
+/* start mail-return layout */
+#acore-mail-return-page {
+    max-width: 100%;
+}
+
+#mail-return-layout {
+    display: grid;
+    grid-template-columns: 460px 1fr 1fr;
+    gap: 16px;
+    align-items: start;
+}
+
+/* col 1 — always the same width */
+#mail-return-sidebar {
+    grid-column: 1;
+}
+
+/* cols 2–3 — hidden until mails exist */
+#mail-return-content {
+    display: none;
+    grid-column: 2 / 4;
+}
+
+/* "Unread Sent Mails" heading — inside card-header */
+#mail-return-heading {
+    font-size: 14px;
+    font-weight: 600;
+}
+
+/* mail entries fill cols 2–3 as a 2-column inner grid */
+#mail-return-items {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+@media (max-width: 800px) {
+    #mail-return-layout {
+        grid-template-columns: 1fr;
+    }
+    #mail-return-content {
+        grid-column: 1;
+    }
+    #mail-return-items {
+        grid-template-columns: 1fr;
+    }
+}
+/* end mail-return layout */
+
 /* start mail-return */
 #mail-return-items .mail-entry {
     background: #fff;
-    border: 1px solid #ccd0d4;
+    /* JS overrides colors per-mail; thickness mirrors character selector rows */
+    border-top: 2px solid #ccd0d4;
+    border-right: 2px solid #ccd0d4;
+    border-bottom: 2px solid #ccd0d4;
+    border-left: 4px solid #646970;
     border-radius: 4px;
     padding: 12px;
-    margin-bottom: 10px;
 }
 
+/* Row 1: recipient left, return button right — class-colored border-left */
 #mail-return-items .mail-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-}
-
-#mail-return-items .mail-subject {
-    font-weight: 600;
-    font-size: 14px;
+    gap: 8px;
+    margin-bottom: 8px;
+    /* avoid border shorthand so JS inline border-left-color wins */
+    border-top: 1px solid #dcdcde;
+    border-right: 1px solid #dcdcde;
+    border-bottom: 1px solid #dcdcde;
+    border-left: 4px solid #646970; /* JS overrides color per card */
+    border-radius: 2px;
+    padding: 7px 10px;
+    background: #f9f9f9;
 }
 
 #mail-return-items .mail-recipient {
     display: flex;
     align-items: center;
     gap: 6px;
-    margin-top: 8px;
-    padding: 6px 10px;
-    background: #f6f7f7;
-    border-radius: 4px;
+    flex-wrap: wrap;
+    background: none;
+    padding: 0;
+    margin: 0;
 }
 
-#mail-return-items .mail-recipient img {
+#mail-return-items .mail-recipient-icon {
     display: inline-block;
-    vertical-align: middle;
-    height: 24px;
-    width: 24px;
+    height: 28px;
+    width: 28px;
     transform: translateZ(0);
-}
-
-#mail-return-items .mail-recipient .recipient-name {
-    font-weight: 500;
-}
-
-#mail-return-items .mail-meta {
-    color: #646970;
-    font-size: 12px;
-    margin-top: 6px;
-}
-
-#mail-return-items .mail-items {
-    margin-top: 8px;
-    padding: 6px 10px;
-    background: #f6f7f7;
+    border: 3px solid rgba(0, 0, 0, 0.18);
     border-radius: 4px;
-    font-size: 13px;
 }
 
-#mail-return-items .mail-money {
-    margin-top: 6px;
-    font-size: 13px;
+#mail-return-items .mail-to-label {
+    font-size: 12px;
     color: #646970;
+    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+#mail-return-items .recipient-name {
+    font-weight: 600;
+    font-size: 14px;
+}
+
+#mail-return-items .recipient-level {
+    font-size: 11px;
+    color: #646970;
+    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+/* Row 2: subject */
+#mail-return-items .mail-subject {
+    font-size: 13px;
+    color: #50575e;
+    margin-bottom: 8px;
+}
+#mail-return-items .mail-subject-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #8b949e;
+    margin-right: 3px;
+}
+
+.mail-cod-label {
+    font-size: 12px;
+    color: #a00;
+}
+
+/* Row 3: item icon grid — centered in card */
+.mail-items-grid {
+    display: grid;
+    grid-template-columns: repeat(6, 56px);
+    gap: 6px;
+    justify-content: center;
+}
+
+@media (max-width: 480px) {
+    .mail-items-grid {
+        grid-template-columns: repeat(4, 56px);
+    }
+}
+
+.mail-item-slot {
+    position: relative;
+    width: 56px;
+    height: 56px;
+    background: #1c1c1c;
+    border: 3px solid rgba(255, 255, 255, 0.22);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.mail-item-slot > a {
+    position: absolute;
+    inset: 0;
+    display: block;
+    font-size: 0;
+    line-height: 0;
+    color: transparent !important;
+    overflow: hidden;
+    /* WowHead sets background-image inline on the <a> — override size/position */
+    background-size: cover !important;
+    background-position: center !important;
+    background-repeat: no-repeat !important;
+}
+
+/* Quantity — bottom strip with semi-transparent overlay */
+.mail-item-qty {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(0, 0, 0, 0.55);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 700;
+    text-align: center;
+    padding: 2px 0 1px;
+    line-height: 1.3;
+    letter-spacing: 0.02em;
+    pointer-events: none;
+    z-index: 2;
 }
 
 #mail-return-items .mail-return-button {
@@ -277,6 +534,7 @@ body {
     cursor: pointer;
     white-space: nowrap;
     font-size: 13px;
+    flex-shrink: 0;
 }
 
 #mail-return-items .mail-return-button:hover {
@@ -289,3 +547,233 @@ body {
     cursor: not-allowed;
 }
 /* end mail-return */
+
+/* ============================================================
+   Profile page & sub-tabs layout (applies to both light + dark)
+   ============================================================ */
+
+body.profile-php #wpbody-content > .wrap {
+    max-width: 900px;
+}
+
+body.profile-php .form-table th {
+    width: 180px;
+    padding: 12px 10px 12px 0;
+    vertical-align: top;
+    font-size: 13px;
+}
+
+body.profile-php .form-table td {
+    padding: 10px 0;
+}
+
+/* --- Security sub-page --- */
+#acore-security-page {
+    max-width: 760px;
+}
+
+#acore-security-page > h1 {
+    margin-bottom: 4px;
+    padding-bottom: 0;
+    border-bottom: none;
+}
+
+#acore-security-page .postbox {
+    border-radius: 3px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.07);
+    margin-top: 16px;
+    margin-bottom: 0;
+}
+
+#acore-security-page .postbox .inside {
+    padding: 16px 20px;
+}
+
+/* Postbox header — padding, cursor, typography */
+#acore-security-page .postbox-header {
+    cursor: default;
+    border-bottom: 1px solid #dcdcde;
+}
+
+#acore-security-page .postbox-header h2,
+#acore-security-page .postbox-header .hndle {
+    cursor: default;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 10px 16px;
+    margin: 0;
+    border: none;
+}
+
+#acore-security-page .form-table th {
+    width: 180px;
+    padding: 10px 10px 10px 0;
+}
+
+#acore-security-page .form-table td {
+    padding: 8px 0;
+}
+
+/* --- RAF sub-page --- */
+#acore-raf-page {
+    max-width: 860px;
+}
+
+#acore-raf-page > h1 {
+    margin-bottom: 6px;
+}
+
+.acore-raf-intro {
+    color: #646970;
+    margin-bottom: 12px;
+}
+
+.acore-raf-notice {
+    max-width: 700px;
+    margin-bottom: 16px !important;
+}
+
+.acore-raf-row {
+    margin-top: 4px;
+}
+
+#acore-raf-page .card {
+    margin-bottom: 16px;
+}
+
+/* --- Item Restoration sub-page --- */
+#acore-item-restoration-page {
+    max-width: 100%;
+}
+
+#acore-item-restoration-page > h1 {
+    margin-bottom: 16px;
+}
+
+/* Layout: sidebar + content (mirrors mail-return) */
+#item-restore-layout {
+    display: grid;
+    grid-template-columns: 460px 1fr;
+    gap: 16px;
+    align-items: start;
+}
+
+#item-restore-sidebar {
+    grid-column: 1;
+}
+
+#item-restore-content {
+    grid-column: 2;
+}
+
+@media (max-width: 800px) {
+    #item-restore-layout {
+        grid-template-columns: 1fr;
+    }
+    #item-restore-content {
+        grid-column: 1;
+    }
+}
+
+/* click cursor + active state (mirrors mail return) */
+#acore-characters-item-restore .acore-char-row {
+    cursor: pointer;
+}
+
+#acore-characters-item-restore .acore-char-row.active {
+    background: #f0f4f8;
+    border-top-width: 3px;
+    border-right-width: 3px;
+    border-bottom-width: 3px;
+}
+
+/* Item restore: 4-column card grid */
+.item-restore-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+}
+
+/* Card: white bg, quality-coloured border (set by JS after wowhead loads) */
+.item-restore-card {
+    position: relative;
+    background: #fff;
+    border: 3px solid #9d9d9d;
+    border-radius: 4px;
+    padding: 20px 12px 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+}
+
+/* Number badge — top-left corner */
+.item-restore-num {
+    position: absolute;
+    top: 6px;
+    left: 8px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #646970;
+    line-height: 1;
+}
+
+/* Icon container */
+.item-restore-icon {
+    position: relative;
+    width: 80px;
+    height: 80px;
+    background: #1c1c1c;
+    border-radius: 3px;
+    overflow: hidden;
+    flex-shrink: 0;
+}
+
+/* WowHead puts icon as background-image on the <a>.
+   font-size/color hide the item-name text wowhead injects. */
+.item-restore-icon > a {
+    position: absolute !important;
+    inset: 0 !important;
+    display: block !important;
+    width: 100% !important;
+    height: 100% !important;
+    font-size: 0 !important;
+    line-height: 0 !important;
+    color: transparent !important;
+    text-indent: -9999px !important;
+    overflow: hidden !important;
+    background-size: cover !important;
+    background-position: center !important;
+    background-repeat: no-repeat !important;
+    padding: 0 !important;
+}
+
+/* Deleted date */
+.item-restore-date {
+    font-size: 11px;
+    color: #646970;
+    text-align: center;
+    line-height: 1.3;
+}
+
+.item-restore-btn {
+    background: #2271b1;
+    color: #fff;
+    border: 1px solid #2271b1;
+    border-radius: 3px;
+    padding: 5px 0;
+    cursor: pointer;
+    font-size: 13px;
+    width: 100%;
+    text-align: center;
+}
+
+.item-restore-btn:hover {
+    background: #135e96;
+    border-color: #135e96;
+}
+
+.item-restore-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}

--- a/src/acore-wp-plugin/web/assets/css/theme.css
+++ b/src/acore-wp-plugin/web/assets/css/theme.css
@@ -1,0 +1,616 @@
+/* =====================================================================
+ * acore-theme.css
+ * Single place to edit light/dark theming for the AzerothCore plugin.
+ *
+ * Colours are driven by CSS custom properties. Edit the values in the
+ * two blocks below (":root" = light, "body.acore-dark-mode" = dark) and
+ * every rule further down updates automatically.
+ *
+ * Loaded after main.css and dark-mode.css, so rules here win.
+ * ===================================================================== */
+
+:root {
+    --acore-bg:            #ffffff;
+    --acore-surface:       #ffffff;
+    --acore-surface-2:     #f3f4f5;
+    --acore-text:          #1d2327;
+    --acore-muted:         #646970;
+    --acore-border:        #c3c4c7;
+    --acore-border-strong: #8c8f94;
+    --acore-accent:        #2271b1;
+    --acore-danger:        #d63638;
+    --acore-danger-bg:     #fbeaea;
+    --acore-danger-text:   #b32d2e;
+
+    /* WoW item-quality colours (shared by both themes) */
+    --q0: #9d9d9d; --q1: #ffffff; --q2: #1eff00; --q3: #0070dd;
+    --q4: #a335ee; --q5: #ff8000; --q6: #e6cc80; --q7: #e6cc80;
+}
+
+body.acore-dark-mode {
+    --acore-bg:            #0d1117;
+    --acore-surface:       #161b22;
+    --acore-surface-2:     #21262d;
+    --acore-text:          #c9d1d9;
+    --acore-muted:         #9aa4af;
+    --acore-border:        #30363d;
+    --acore-border-strong: #484f58;
+    --acore-accent:        #58a6ff;
+    --acore-danger:        #d63638;
+    --acore-danger-bg:     transparent;
+    --acore-danger-text:   #ea5a5c;
+
+    --q1: #c0c0c0; /* pure white reads poorly on dark; soften common quality */
+}
+
+/* ── Danger buttons (Reset Order, Remove, Reset, …) ─────────────────── */
+body.acore-dark-mode .acore-btn-danger .dashicons {
+    color: var(--acore-danger-text) !important;
+}
+.acore-btn-danger {
+    border: 1px solid var(--acore-danger) !important;
+    color: var(--acore-danger-text) !important;
+    background: var(--acore-danger-bg) !important;
+    transition: background .12s ease, color .12s ease;
+}
+.acore-btn-danger:hover,
+.acore-btn-danger:focus {
+    background: var(--acore-danger) !important;
+    color: #ffffff !important;
+}
+.acore-btn-danger .dashicons { margin-top: 3px; }
+
+/* ── Item Restoration: cards ────────────────────────────────────────── */
+/* Outer card: neutral border + theme surface (works light & dark).      */
+.item-restore-card {
+    background: var(--acore-surface) !important;
+    border: 1px solid var(--acore-border) !important;
+    color: var(--acore-text) !important;
+    border-radius: 6px;
+}
+.item-restore-card .item-restore-date { color: var(--acore-muted) !important; }
+.item-restore-card .item-restore-num  { color: var(--acore-muted) !important; }
+/* Inner icon shows the item quality as its border. wowhead adds q0..q7   */
+/* to the icon link; we colour the icon frame from that.                  */
+.item-restore-icon a {
+    display: block;
+    border: 2px solid var(--acore-border-strong);
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+.item-restore-icon a.q0 { border-color: var(--q0) !important; }
+.item-restore-icon a.q1 { border-color: var(--q1) !important; }
+.item-restore-icon a.q2 { border-color: var(--q2) !important; }
+.item-restore-icon a.q3 { border-color: var(--q3) !important; }
+.item-restore-icon a.q4 { border-color: var(--q4) !important; }
+.item-restore-icon a.q5 { border-color: var(--q5) !important; }
+.item-restore-icon a.q6 { border-color: var(--q6) !important; }
+.item-restore-icon a.q7 { border-color: var(--q7) !important; }
+
+/* ── Security page: readability in dark mode ────────────────────────── */
+/* Inline muted greys (#646970) are too dark on a dark surface.          */
+body.acore-dark-mode #acore-security-page [style*="646970"],
+body.acore-dark-mode #acore-security-page [style*="#646970"],
+body.acore-dark-mode #acore-security-page .description,
+body.acore-dark-mode #acore-security-page .text-muted {
+    color: var(--acore-muted) !important;
+}
+body.acore-dark-mode #acore-security-page,
+body.acore-dark-mode #acore-security-page p,
+body.acore-dark-mode #acore-security-page li,
+body.acore-dark-mode #acore-security-page h3 { color: var(--acore-text); }
+body.acore-dark-mode #acore-security-page code {
+    background: var(--acore-surface-2) !important;
+    color: var(--acore-text) !important;
+    border: 1px solid var(--acore-border);
+    border-radius: 3px;
+    padding: 1px 5px;
+}
+/* Recent Connections table - stripe rows at the <tr> level so WP's light
+   .striped odd-row background doesn't show through transparent cells. */
+body.acore-dark-mode #acore-security-page .wp-list-table {
+    background: var(--acore-surface) !important;
+    border-color: var(--acore-border) !important;
+}
+body.acore-dark-mode #acore-security-page .wp-list-table > thead > tr,
+body.acore-dark-mode #acore-security-page .wp-list-table > tbody > tr:nth-child(odd) {
+    background: var(--acore-surface-2) !important;
+}
+body.acore-dark-mode #acore-security-page .wp-list-table > tbody > tr:nth-child(even) {
+    background: var(--acore-surface) !important;
+}
+body.acore-dark-mode #acore-security-page .wp-list-table th,
+body.acore-dark-mode #acore-security-page .wp-list-table td {
+    color: var(--acore-text) !important;
+    border-color: var(--acore-border) !important;
+    background: transparent !important;
+}
+
+/* ── Mail Return surfaces ───────────────────────────────────────────── */
+body.acore-dark-mode #acore-mail-return-page .mail-entry { background: var(--acore-surface) !important; }
+body.acore-dark-mode #acore-mail-return-page .mail-recipient,
+body.acore-dark-mode #acore-mail-return-page .mail-items { background: var(--acore-bg) !important; }
+body.acore-dark-mode #acore-mail-return-page .mail-entry *,
+body.acore-dark-mode #acore-mail-return-page .mail-meta { color: var(--acore-text) !important; }
+body.acore-dark-mode #acore-mail-return-page .text-muted { color: var(--acore-muted) !important; }
+
+/* ── WP 2FA plugin UI (embedded on the Security page) ───────────────── */
+body.acore-dark-mode #acore-security-page [class*="wp2fa"],
+body.acore-dark-mode #acore-security-page [class*="wp-2fa"] { color: var(--acore-text) !important; }
+body.acore-dark-mode #acore-security-page [class*="wp2fa"] input,
+body.acore-dark-mode #acore-security-page [class*="wp2fa"] select,
+body.acore-dark-mode #acore-security-page [class*="wp2fa"] textarea {
+    background: var(--acore-surface-2) !important;
+    color: var(--acore-text) !important;
+    border: 1px solid var(--acore-border) !important;
+}
+body.acore-dark-mode #acore-security-page [class*="wp2fa"] code,
+body.acore-dark-mode #acore-security-page [class*="wp2fa"] pre {
+    background: var(--acore-surface-2) !important;
+    color: var(--acore-text) !important;
+}
+
+/* ── myCRED points / history page (profile.php?page=mycred_default-history) ── */
+body.acore-dark-mode.mycred-log-page #wpbody-content { color: var(--acore-text); }
+
+/* Filter tabs (All / Today / This Week …) */
+body.acore-dark-mode.mycred-log-page .subsubsub,
+body.acore-dark-mode.mycred-log-page .subsubsub a { color: var(--acore-muted) !important; }
+body.acore-dark-mode.mycred-log-page .subsubsub a.current,
+body.acore-dark-mode.mycred-log-page .subsubsub a:hover { color: var(--acore-accent) !important; }
+
+/* Search box + pagination chrome */
+body.acore-dark-mode.mycred-log-page .search-box input,
+body.acore-dark-mode.mycred-log-page .tablenav input,
+body.acore-dark-mode.mycred-log-page .tablenav select {
+    background: var(--acore-surface-2) !important;
+    color: var(--acore-text) !important;
+    border: 1px solid var(--acore-border) !important;
+}
+body.acore-dark-mode.mycred-log-page .tablenav,
+body.acore-dark-mode.mycred-log-page .tablenav * { color: var(--acore-text) !important; }
+body.acore-dark-mode.mycred-log-page .tablenav .tablenav-pages a,
+body.acore-dark-mode.mycred-log-page .tablenav .tablenav-pages span.tablenav-pages-navspan {
+    background: var(--acore-surface-2) !important;
+    border-color: var(--acore-border) !important;
+    color: var(--acore-text) !important;
+}
+
+/* The points-history list table */
+body.acore-dark-mode.mycred-log-page .wp-list-table {
+    background: var(--acore-surface) !important;
+    border-color: var(--acore-border) !important;
+    color: var(--acore-text) !important;
+}
+body.acore-dark-mode.mycred-log-page .wp-list-table thead th,
+body.acore-dark-mode.mycred-log-page .wp-list-table tfoot th,
+body.acore-dark-mode.mycred-log-page .wp-list-table thead th a,
+body.acore-dark-mode.mycred-log-page .wp-list-table thead th span {
+    background: var(--acore-surface-2) !important;
+    color: var(--acore-text) !important;
+    border-color: var(--acore-border) !important;
+}
+body.acore-dark-mode.mycred-log-page .wp-list-table td,
+body.acore-dark-mode.mycred-log-page .wp-list-table th {
+    color: var(--acore-text) !important;
+    border-color: var(--acore-border) !important;
+    background: transparent !important;
+}
+body.acore-dark-mode.mycred-log-page .wp-list-table > tbody > tr:nth-child(odd) {
+    background: var(--acore-surface-2) !important;
+}
+body.acore-dark-mode.mycred-log-page .wp-list-table a { color: var(--acore-accent) !important; }
+
+/* Export button row */
+body.acore-dark-mode.mycred-log-page #export-log-history,
+body.acore-dark-mode.mycred-log-page #export-log-history * { color: var(--acore-text) !important; }
+
+/* Generic myCRED widgets elsewhere (points balance boxes, etc.) */
+body.acore-dark-mode [class*="mycred"] th,
+body.acore-dark-mode [class*="mycred"] td { color: var(--acore-text) !important; border-color: var(--acore-border) !important; }
+body.acore-dark-mode [class*="mycred"] a { color: var(--acore-accent) !important; }
+
+/* myCRED page outer wrapper (#myCRED-wrap is white) -> blend into dark admin bg */
+body.acore-dark-mode.mycred-log-page #myCRED-wrap {
+    background: transparent !important;
+}
+body.acore-dark-mode.mycred-log-page #myCRED-wrap,
+body.acore-dark-mode.mycred-log-page #myCRED-wrap h1,
+body.acore-dark-mode.mycred-log-page #myCRED-wrap h2,
+body.acore-dark-mode.mycred-log-page #myCRED-wrap p {
+    color: var(--acore-text) !important;
+}
+
+/* ── WP 2FA standalone setup wizard (profile.php?page=wp-2fa-setup) ──────
+ * The wizard renders its own <body class="wp2fa-setup"> with no admin/dark
+ * class, and only prints its own stylesheets. We inject theme.css into its
+ * <head> via the `wp_2fa_setup_page_scripts` hook ONLY when dark mode is on
+ * (see DarkMode.php), so these body.wp2fa-setup rules are dark-only by load.
+ * The dark palette is redeclared here because .acore-dark-mode isn't present. */
+body.wp2fa-setup {
+    --acore-bg:            #0d1117;
+    --acore-surface:       #161b22;
+    --acore-surface-2:     #21262d;
+    --acore-text:          #c9d1d9;
+    --acore-muted:         #9aa4af;
+    --acore-border:        #30363d;
+    --acore-accent:        #58a6ff;
+
+    background: var(--acore-bg) !important;
+    color: var(--acore-text) !important;
+}
+body.wp2fa-setup .setup-wizard-wrapper,
+body.wp2fa-setup .wp2fa-setup-content,
+body.wp2fa-setup .modal__container {
+    background: var(--acore-surface) !important;
+    color: var(--acore-text) !important;
+    border-color: var(--acore-border) !important;
+}
+body.wp2fa-setup h1, body.wp2fa-setup h2, body.wp2fa-setup h3,
+body.wp2fa-setup h4, body.wp2fa-setup p, body.wp2fa-setup label,
+body.wp2fa-setup li, body.wp2fa-setup span, body.wp2fa-setup strong {
+    color: var(--acore-text) !important;
+}
+body.wp2fa-setup .description,
+body.wp2fa-setup .wp2fa-setup-footer a { color: var(--acore-muted) !important; }
+body.wp2fa-setup input[type="text"],
+body.wp2fa-setup input[type="email"],
+body.wp2fa-setup input[type="number"],
+body.wp2fa-setup input[type="password"],
+body.wp2fa-setup select,
+body.wp2fa-setup textarea,
+body.wp2fa-setup .select2-selection {
+    background: var(--acore-surface-2) !important;
+    color: var(--acore-text) !important;
+    border: 1px solid var(--acore-border) !important;
+}
+body.wp2fa-setup .steps li { color: var(--acore-muted) !important; }
+body.wp2fa-setup .steps li.is-active { color: var(--acore-accent) !important; font-weight: 600; }
+body.wp2fa-setup .button-secondary,
+body.wp2fa-setup .wp-2fa-button-secondary {
+    background: var(--acore-surface-2) !important;
+    color: var(--acore-text) !important;
+    border-color: var(--acore-border) !important;
+}
+body.wp2fa-setup code,
+body.wp2fa-setup pre {
+    background: var(--acore-surface-2) !important;
+    color: var(--acore-text) !important;
+    border: 1px solid var(--acore-border);
+}
+body.wp2fa-setup .modal__overlay { background: rgba(0,0,0,0.6) !important; }
+
+/* ── WP 2FA micromodal on normal admin pages (Security page "Configure 2FA") ──
+ * The modal is appended at <body> level (outside #acore-security-page), so it is
+ * scoped by the body dark class instead. */
+body.acore-dark-mode .wp2fa-modal .modal__container {
+    background: var(--acore-surface) !important;
+    color: var(--acore-text) !important;
+}
+body.acore-dark-mode .wp2fa-modal .modal__content,
+body.acore-dark-mode .wp2fa-modal .modal__content h1,
+body.acore-dark-mode .wp2fa-modal .modal__content h2,
+body.acore-dark-mode .wp2fa-modal .modal__content h3,
+body.acore-dark-mode .wp2fa-modal .modal__content h4,
+body.acore-dark-mode .wp2fa-modal .modal__content p,
+body.acore-dark-mode .wp2fa-modal .modal__content label,
+body.acore-dark-mode .wp2fa-modal .modal__content span,
+body.acore-dark-mode .wp2fa-modal .modal__content li,
+body.acore-dark-mode .wp2fa-modal .modal__content strong {
+    color: var(--acore-text) !important;
+}
+body.acore-dark-mode .wp2fa-modal .description { color: var(--acore-muted) !important; }
+body.acore-dark-mode .wp2fa-modal .option-pill,
+body.acore-dark-mode .wp2fa-modal .radio-cells .option-pill {
+    background: var(--acore-surface-2) !important;
+    border-color: var(--acore-border) !important;
+    color: var(--acore-text) !important;
+}
+body.acore-dark-mode .wp2fa-modal .option-pill.selected,
+body.acore-dark-mode .wp2fa-modal .option-pill:hover {
+    border-color: var(--acore-accent) !important;
+}
+body.acore-dark-mode .wp2fa-modal input,
+body.acore-dark-mode .wp2fa-modal select,
+body.acore-dark-mode .wp2fa-modal textarea {
+    background: var(--acore-surface-2) !important;
+    color: var(--acore-text) !important;
+    border: 1px solid var(--acore-border) !important;
+}
+body.acore-dark-mode .wp2fa-modal .modal__close { color: var(--acore-text) !important; }
+body.acore-dark-mode .wp2fa-modal code,
+body.acore-dark-mode .wp2fa-modal pre {
+    background: var(--acore-surface-2) !important;
+    color: var(--acore-text) !important;
+    border: 1px solid var(--acore-border);
+}
+
+/* WP 2FA TOTP secret-key box (shown in both the modal and the wizard) */
+body.acore-dark-mode .wp2fa-modal .app-key-wrapper,
+body.wp2fa-setup .app-key-wrapper {
+    background: var(--acore-surface-2) !important;
+    border-color: var(--acore-border) !important;
+}
+body.acore-dark-mode .wp2fa-modal .app-key-wrapper .app-key,
+body.acore-dark-mode .wp2fa-modal .app-key-wrapper input,
+body.wp2fa-setup .app-key-wrapper .app-key,
+body.wp2fa-setup .app-key-wrapper input {
+    color: var(--acore-text) !important;
+}
+
+
+/* ── "Disabled" sections (e.g. In-game 2FA before Website 2FA is set up) ──
+ * A greyed background box signals "disabled" while text stays fully legible
+ * (no opacity wash-out). Works in both light and dark themes. */
+.acore-2fa-disabled {
+    position: relative;
+    pointer-events: none;
+    user-select: none;
+    background: var(--acore-surface-2);
+    border: 1px solid var(--acore-border);
+    border-radius: 6px;
+    padding: 10px 16px 12px;
+    margin-top: 8px;
+}
+/* Light theme: keep the intro + steps at readable contrast on the grey box */
+.acore-2fa-disabled p,
+.acore-2fa-disabled li { color: #3c434a !important; }
+.acore-2fa-disabled p:first-child { color: #50575e !important; }
+/* Dark theme */
+body.acore-dark-mode .acore-2fa-disabled,
+body.acore-dark-mode .acore-2fa-disabled p,
+body.acore-dark-mode .acore-2fa-disabled li,
+body.acore-dark-mode .acore-2fa-disabled span { color: var(--acore-text) !important; }
+body.acore-dark-mode .acore-2fa-disabled p:first-child { color: var(--acore-muted) !important; }
+
+/* ── "Website 2FA required" callout (bright & visible in both themes) ── */
+.acore-2fa-required-note {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 10px 0 0;
+    padding: 8px 12px;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.4;
+    border-radius: 6px;
+    color: #9a5b00;
+    background: #fff4e0;
+    border: 1px solid #f0b429;
+}
+.acore-2fa-required-note .dashicons { color: #d98300; flex: 0 0 auto; }
+body.acore-dark-mode .acore-2fa-required-note {
+    color: #f5c451 !important;
+    background: rgba(240, 180, 41, 0.12) !important;
+    border-color: #8a6d1f !important;
+}
+body.acore-dark-mode .acore-2fa-required-note .dashicons { color: #f5c451 !important; }
+
+/* ── Highlight the connection row matching the viewer's current IP ── */
+#acore-security-page .wp-list-table > tbody > tr.acore-conn-current > td {
+    background: #fff3cd !important;
+    border-color: #f0d488 !important;
+}
+#acore-security-page .wp-list-table > tbody > tr.acore-conn-current > td:first-child {
+    box-shadow: inset 3px 0 0 0 #e0a800;
+    font-weight: 600;
+}
+body.acore-dark-mode #acore-security-page .wp-list-table > tbody > tr.acore-conn-current > td {
+    background: rgba(240, 180, 41, 0.16) !important;
+    color: #f5d98a !important;
+    border-color: #6e5a1e !important;
+}
+body.acore-dark-mode #acore-security-page .wp-list-table > tbody > tr.acore-conn-current > td:first-child {
+    box-shadow: inset 3px 0 0 0 #f0b429;
+}
+
+/* ── Shared connection tables (Security page + Profile page) ── */
+body.acore-dark-mode .acore-conn-table {
+    background: var(--acore-surface) !important;
+    border-color: var(--acore-border) !important;
+}
+body.acore-dark-mode .acore-conn-table > thead > tr,
+body.acore-dark-mode .acore-conn-table > tbody > tr:nth-child(odd) {
+    background: var(--acore-surface-2) !important;
+}
+body.acore-dark-mode .acore-conn-table > tbody > tr:nth-child(even) {
+    background: var(--acore-surface) !important;
+}
+body.acore-dark-mode .acore-conn-table th,
+body.acore-dark-mode .acore-conn-table td {
+    color: var(--acore-text) !important;
+    border-color: var(--acore-border) !important;
+    background: transparent !important;
+}
+.acore-conn-table > tbody > tr.acore-conn-current > td {
+    background: #fff3cd !important;
+    border-color: #f0d488 !important;
+}
+.acore-conn-table > tbody > tr.acore-conn-current > td:first-child {
+    box-shadow: inset 3px 0 0 0 #e0a800;
+    font-weight: 600;
+}
+body.acore-dark-mode .acore-conn-table > tbody > tr.acore-conn-current > td {
+    background: rgba(240, 180, 41, 0.16) !important;
+    color: #f5d98a !important;
+    border-color: #6e5a1e !important;
+}
+body.acore-dark-mode .acore-conn-table > tbody > tr.acore-conn-current > td:first-child {
+    box-shadow: inset 3px 0 0 0 #f0b429;
+}
+
+/* "Your IPv4:" label (right-aligned) + connection notes - readable both themes */
+.acore-conn-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+    max-width: 860px;
+    flex-wrap: wrap;
+}
+.acore-conn-myip {
+    font-size: 13px;
+    font-weight: 400;
+    white-space: nowrap;
+    color: #50575e;
+}
+body.acore-dark-mode .acore-conn-myip { color: #c9d1d9; }
+.acore-conn-note { color: #50575e; font-size: 13px; }
+body.acore-dark-mode .acore-conn-note { color: #9aa4af !important; }
+
+/* ── Dark-mode toggle in the admin bar (visible in both themes) ────────── */
+#wp-admin-bar-acore-dark-mode > .ab-item {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 4px;
+}
+#wp-admin-bar-acore-dark-mode:hover > .ab-item {
+    background: rgba(255, 255, 255, 0.18) !important;
+}
+#acore-dm-icon {
+    font-size: 18px !important;
+    line-height: 1 !important;
+    color: #ffc83d !important;
+    vertical-align: middle;
+}
+
+/* ── Native <select> dropdowns inside our cards (dark) ─────────────────── */
+body.acore-dark-mode .card select,
+body.acore-dark-mode .wrap select {
+    background-color: var(--acore-surface-2) !important;
+    color: var(--acore-text) !important;
+    border: 1px solid var(--acore-border) !important;
+}
+body.acore-dark-mode .card select option,
+body.acore-dark-mode .wrap select option {
+    background-color: #161b22;
+    color: var(--acore-text);
+}
+
+/* ── Disabled buttons in dark mode (no more white blobs) ───────────────── */
+body.acore-dark-mode .acore-btn-danger:disabled,
+body.acore-dark-mode .acore-btn-danger[disabled],
+body.acore-dark-mode .card .button:disabled,
+body.acore-dark-mode .card .button[disabled] {
+    background: var(--acore-surface-2) !important;
+    color: #6e7681 !important;
+    border-color: var(--acore-border) !important;
+    opacity: 0.7 !important;
+    text-shadow: none !important;
+}
+
+/* ── Text / number inputs inside our cards (dark) ─────────────────────── */
+body.acore-dark-mode .card input[type="text"],
+body.acore-dark-mode .card input[type="number"],
+body.acore-dark-mode .card input[type="search"],
+body.acore-dark-mode .card input[type="password"],
+body.acore-dark-mode .card input[type="email"],
+body.acore-dark-mode .card textarea,
+body.acore-dark-mode .wrap > .card input[type="number"] {
+    background-color: var(--acore-surface-2) !important;
+    color: var(--acore-text) !important;
+    border: 1px solid var(--acore-border) !important;
+}
+body.acore-dark-mode .card input::placeholder { color: #6e7681 !important; }
+/* tone down the native number spinner so it isn't a white block on dark */
+body.acore-dark-mode .card input[type="number"]::-webkit-inner-spin-button,
+body.acore-dark-mode .card input[type="number"]::-webkit-outer-spin-button {
+    filter: invert(0.85) hue-rotate(180deg);
+}
+
+/* ── Primary (blue) buttons in dark mode - a nicer blue than plain grey ── */
+body.acore-dark-mode .button-primary,
+body.acore-dark-mode .button-primary:focus {
+    background: #2f81f7 !important;
+    border-color: #1f6feb !important;
+    color: #ffffff !important;
+    text-shadow: none !important;
+    box-shadow: none !important;
+}
+body.acore-dark-mode .button-primary:hover {
+    background: #4493f8 !important;
+    border-color: #2f81f7 !important;
+    color: #ffffff !important;
+}
+
+/* ── Secondary / default buttons in dark mode (blue-tinted, not bland grey) ── */
+body.acore-dark-mode .button:not(.button-primary):not(.acore-btn-danger),
+body.acore-dark-mode .button-secondary:not(.acore-btn-danger) {
+    background: #1c2b45 !important;       /* distinct navy so the button stands out from the card */
+    border-color: #388bfd !important;
+    color: #79c0ff !important;            /* brighter blue - dark equivalent of the white theme's #2271b1 */
+}
+body.acore-dark-mode .button:not(.button-primary):not(.acore-btn-danger) .dashicons {
+    color: #79c0ff !important;
+}
+body.acore-dark-mode .button:not(.button-primary):not(.acore-btn-danger):hover,
+body.acore-dark-mode .button-secondary:not(.acore-btn-danger):hover {
+    background: #2f81f7 !important;
+    border-color: #2f81f7 !important;
+    color: #ffffff !important;
+}
+body.acore-dark-mode .button:not(.button-primary):not(.acore-btn-danger):hover .dashicons {
+    color: #ffffff !important;
+}
+
+/* WP 2FA modal response message (error/success) - dark box + light text so it's
+   readable instead of WP2FA's light-pink box with faint text. :not(:empty) so it
+   only styles when a message is actually shown; the coloured border (red/green)
+   from WP2FA is kept to convey error vs success. */
+body.acore-dark-mode .wp2fa-modal .verification-response:not(:empty) {
+    background: #21262d !important;
+    border-radius: 6px !important;
+    padding: 10px 14px !important;
+}
+body.acore-dark-mode .wp2fa-modal .verification-response:not(:empty),
+body.acore-dark-mode .wp2fa-modal .verification-response:not(:empty) * {
+    color: #e6edf3 !important;
+}
+
+/* ── myCRED history: filter-tab pills + search button (were white) ──────── */
+body.acore-dark-mode.mycred-log-page .subsubsub a {
+    background: #21262d !important;
+    border: 1px solid #30363d !important;
+    border-radius: 4px;
+    color: #c9d1d9 !important;
+}
+body.acore-dark-mode.mycred-log-page .subsubsub a.current,
+body.acore-dark-mode.mycred-log-page .subsubsub a:hover {
+    background: #2f81f7 !important;
+    border-color: #2f81f7 !important;
+    color: #ffffff !important;
+}
+body.acore-dark-mode.mycred-log-page #search-submit,
+body.acore-dark-mode.mycred-log-page .search-box input[type="submit"],
+body.acore-dark-mode.mycred-log-page .tablenav input[type="submit"] {
+    background: #1c2b45 !important;
+    border: 1px solid #388bfd !important;
+    color: #79c0ff !important;
+}
+
+/* myCRED's mycred-admin-ui.css forces the search submit white !important - override hard */
+body.acore-dark-mode #wpbody-content input#search-submit {
+    background: #1c2b45 !important;
+    background-color: #1c2b45 !important;
+    border: 1px solid #388bfd !important;
+    color: #79c0ff !important;
+}
+
+/* ── myCRED: purple tab text + white checkbox + white .btn (beat mycred's
+   high-specificity rules with a two-ID selector) ───────────────────────── */
+body.acore-dark-mode #wpcontent #wpbody-content .subsubsub a {
+    color: #c792ea !important;   /* brighter lavender - readable on dark */
+}
+body.acore-dark-mode #wpcontent #wpbody-content .subsubsub a.current,
+body.acore-dark-mode #wpcontent #wpbody-content .subsubsub a:hover {
+    color: #ffffff !important;
+}
+body.acore-dark-mode #wpcontent #wpbody-content input[type="checkbox"] {
+    background: #0d1117 !important;
+    border-color: #484f58 !important;
+}
+body.acore-dark-mode #wpcontent #wpbody-content a.btn,
+body.acore-dark-mode #wpcontent #wpbody-content a.btn.btn-primary {
+    background: #1c2b45 !important;
+    border-color: #388bfd !important;
+    color: #79c0ff !important;
+}

--- a/src/acore-wp-plugin/web/assets/mail-return/mail-return.js
+++ b/src/acore-wp-plugin/web/assets/mail-return/mail-return.js
@@ -1,19 +1,21 @@
 jQuery(document).ready(function () {
-    jQuery("#mail-return-char-select").on("change", function () {
-        var charGuid = jQuery(this).val();
-        var mailList = jQuery("#mail-return-list");
+    jQuery("#acore-characters-mail").on("click", ".acore-char-card", function () {
+        var card = jQuery(this);
+        var charGuid = card.data("char-guid");
         var mailItems = jQuery("#mail-return-items");
-        var emptyMsg = jQuery("#mail-return-empty");
-        var loading = jQuery("#mail-return-loading");
+        var emptyWrap = jQuery("#mail-return-empty-wrap");
+        var emptyMsg  = jQuery("#mail-return-empty");
+        var loading   = jQuery("#mail-return-loading");
+        var content   = jQuery("#mail-return-content");
 
-        if (!charGuid) {
-            mailList.hide();
-            return;
-        }
+        jQuery(".acore-char-card").removeClass("active");
+        card.addClass("active");
 
         loading.show();
-        mailList.hide();
         mailItems.empty();
+        emptyMsg.text("No unread sent mails found for this character.");
+        emptyWrap.hide();
+        content.hide();
 
         jQuery.ajax({
             type: "GET",
@@ -22,79 +24,163 @@ jQuery(document).ready(function () {
             xhrFields: { withCredentials: true },
             success: function (mails) {
                 loading.hide();
-                mailList.show();
 
                 if (mails.length === 0) {
-                    emptyMsg.show();
+                    emptyWrap.show();
                     return;
                 }
 
-                emptyMsg.hide();
+                content.show();
+
+                // Class border-left colors (mirrors AcoreCharColors.php light values)
+                var classColors = {
+                    1: '#C69B6D', 2: '#F48CBA', 3: '#AAD372', 4: '#C8A800',
+                    5: '#909090', 6: '#C41E3A', 7: '#0070DD', 8: '#3FC7EB',
+                    9: '#8788EE', 11: '#FF7C0A'
+                };
+
+                // Expansion colors for level display (mirrors User.php / AcoreCharColors.php)
+                function expansionColor(level) {
+                    if (level <= 60) return '#C39361'; // Vanilla
+                    if (level <= 70) return '#62C907'; // TBC
+                    return '#5DACEB';                   // Wrath
+                }
+
+                // Race names (mirrors AcoreCharColors::RACE_NAMES)
+                var raceNames = {
+                    1: 'Human', 2: 'Orc', 3: 'Dwarf', 4: 'Night Elf', 5: 'Undead',
+                    6: 'Tauren', 7: 'Gnome', 8: 'Troll', 10: 'Blood Elf', 11: 'Draenei'
+                };
+                var classNames = {
+                    1: 'Warrior', 2: 'Paladin', 3: 'Hunter', 4: 'Rogue', 5: 'Priest',
+                    6: 'Death Knight', 7: 'Shaman', 8: 'Mage', 9: 'Warlock', 11: 'Druid'
+                };
+
+                // Faction colors (mirrors AcoreCharColors::FACTION_COLORS)
+                var allianceRaces = [1, 3, 4, 7, 11];
+                function factionClr(raceId) {
+                    return allianceRaces.indexOf(raceId) !== -1 ? '#3FACF4' : '#FF653D';
+                }
 
                 mails.forEach(function (mail) {
-                    var sentDate = new Date(mail.deliver_time * 1000).toLocaleString();
                     var genderSuffix = mail.receiver_gender == 0 ? "m" : "f";
-                    var raceIcon = mailReturnData.assetsUrl + "race/" + mail.receiver_race + genderSuffix + ".webp";
+                    var raceIcon  = mailReturnData.assetsUrl + "race/"  + mail.receiver_race  + genderSuffix + ".webp";
                     var classIcon = mailReturnData.assetsUrl + "class/" + mail.receiver_class + ".webp";
+                    var clsColor  = classColors[mail.receiver_class] || '#646970';
+                    var faction   = factionClr(mail.receiver_race);
+                    var raceName  = raceNames[mail.receiver_race]  || 'Unknown';
+                    var clsName   = classNames[mail.receiver_class] || 'Unknown';
 
-                    // Build items HTML
-                    var itemsHtml = "";
+                    // Subject line — with optional CoD label
+                    var subjectText = mail.subject || "(No Subject)";
+                    var subjectHtml = jQuery('<div>').text(subjectText).html();
+                    var codHtml = (mail.cod && parseInt(mail.cod) > 0)
+                        ? ' <span class="mail-cod-label">· <strong>CoD</strong>: Cash on Delivery</span>'
+                        : '';
+
+                    // WoW item quality → border color
+                    var qualityColors = {
+                        0: '#9d9d9d', // Poor (gray)
+                        1: '#c0c0c0', // Common (white → light grey for dark bg visibility)
+                        2: '#1eff00', // Uncommon (green)
+                        3: '#0070dd', // Rare (blue)
+                        4: '#a335ee', // Epic (purple)
+                        5: '#ff8000', // Legendary (orange)
+                        6: '#e6cc80', // Artifact
+                        7: '#e6cc80', // Heirloom
+                    };
+
+                    // Items grid — quality-colored border, quantity always shown
+                    var itemsHtml = '';
                     if (mail.items && mail.items.length > 0) {
-                        itemsHtml = '<div class="mail-items">';
-                        mail.items.forEach(function (item, idx) {
-                            if (idx > 0) itemsHtml += "&ensp;";
-                            var qty = item.count > 1 ? " x" + item.count : "";
-                            itemsHtml += '<a href="https://www.wowhead.com/wotlk/item=' + item.itemEntry + '" data-wowhead="item=' + item.itemEntry + '">' + item.item_name + '</a>' + qty;
+                        itemsHtml = '<div class="mail-items-grid">';
+                        mail.items.forEach(function (item) {
+                            var safeName    = jQuery('<div>').text(item.item_name).html();
+                            var qualityClr  = qualityColors[item.item_quality] || '#9d9d9d';
+                            itemsHtml += '<div class="mail-item-slot" style="border-color:' + qualityClr + '" title="' + safeName + '">'
+                                + '<a href="https://www.wowhead.com/wotlk/item=' + item.itemEntry
+                                + '" data-wowhead="item=' + item.itemEntry + '" title="' + safeName + '">' + safeName + '</a>'
+                                + '<span class="mail-item-qty">' + item.count + '</span>'
+                                + '</div>';
                         });
-                        itemsHtml += "</div>";
+                        itemsHtml += '</div>';
                     }
 
-                    // Build money HTML
-                    var moneyHtml = "";
-                    if (mail.money > 0) {
-                        moneyHtml = '<div class="mail-money">Money: ' + formatMoney(mail.money) + '</div>';
-                    }
+                    // Level badge: same expansion badge as character selector
+                    var lvlExp = mail.receiver_level <= 60 ? 'vanilla' : (mail.receiver_level <= 70 ? 'tbc' : 'wrath');
+                    var levelBadge = jQuery('<span>')
+                        .addClass('acore-level')
+                        .attr('data-exp', lvlExp)
+                        .text('LEVEL ' + mail.receiver_level);
 
                     var entry = jQuery('<li>').append(
-                        jQuery('<div>').addClass('mail-entry').append(
-                            // Header row: subject + return button
-                            jQuery('<div>').addClass('mail-header').append(
-                                jQuery('<span>').addClass('mail-subject').text(mail.subject || "(No Subject)"),
-                                jQuery('<button>')
-                                    .addClass('mail-return-button')
-                                    .attr('data-mail-id', mail.id)
-                                    .attr('data-char-guid', charGuid)
-                                    .text('Return')
-                            ),
-                            // Recipient bar with icons
-                            jQuery('<div>').addClass('mail-recipient').append(
-                                jQuery('<span>').text('To:'),
-                                jQuery('<img>').attr({ src: raceIcon, alt: 'race' }),
-                                jQuery('<img>').attr({ src: classIcon, alt: 'class' }),
-                                jQuery('<span>').addClass('recipient-name').text(mail.receiver_name),
-                                jQuery('<span>').css('color', '#646970').text('(Level ' + mail.receiver_level + ')')
-                            ),
-                            // Sent date
-                            jQuery('<div>').addClass('mail-meta').text('Sent: ' + sentDate + '  |  Expires: ' + new Date(mail.expire_time * 1000).toLocaleString()),
-                            // Items
-                            jQuery(itemsHtml),
-                            // Money
-                            jQuery(moneyHtml)
+                        jQuery('<div>').addClass('mail-entry').css({
+                            // Faction color on top/right/bottom; class color on left — mirrors char row design
+                            'border-top':    '2px solid ' + faction,
+                            'border-right':  '2px solid ' + faction,
+                            'border-bottom': '2px solid ' + faction,
+                            'border-left':   '4px solid ' + clsColor,
+                        }).append(
+                            // Row 1: To (recipient) + Return button — bordered with class color
+                            jQuery('<div>').addClass('mail-header')
+                                .css('border-left-color', clsColor)
+                                .append(
+                                    jQuery('<div>').addClass('mail-recipient').append(
+                                        jQuery('<span>').addClass('mail-to-label').text('To:'),
+                                        jQuery('<img>').attr({ src: raceIcon,  height: 28, width: 28, alt: raceName, title: raceName }).addClass('mail-recipient-icon').css('border-color', faction),
+                                        jQuery('<img>').attr({ src: classIcon, height: 28, width: 28, alt: clsName,  title: clsName  }).addClass('mail-recipient-icon').css('border-color', clsColor),
+                                        jQuery('<span>').addClass('recipient-name').text(mail.receiver_name),
+                                        levelBadge
+                                    ),
+                                    jQuery('<button>')
+                                        .addClass('mail-return-button')
+                                        .attr('data-mail-id', mail.id)
+                                        .attr('data-char-guid', charGuid)
+                                        .text('Return')
+                                ),
+                            // Row 2: subject + CoD label
+                            jQuery('<div>').addClass('mail-subject').html('<span class="mail-subject-label">Title:</span> <em><strong>' + subjectHtml + '</strong></em>' + codHtml),
+                            // Row 3: item icon grid
+                            jQuery(itemsHtml)
                         )
                     );
 
                     mailItems.append(entry);
                 });
 
-                // Refresh Wowhead tooltips for the newly added links
+                // Refresh Wowhead tooltips + upgrade icons to large JPG
+                function upgradeWowheadIcons() {
+                    document.querySelectorAll('.mail-item-slot > a').forEach(function (a) {
+                        var bg = a.style.backgroundImage;
+                        if (bg) {
+                            bg = bg.replace(/\/icons\/(tiny|small)\//, '/icons/large/')
+                                   .replace(/\.gif(["']?\))/, '.jpg$1');
+                            a.style.backgroundImage = bg;
+                        }
+                    });
+                }
                 if (typeof $WowheadPower !== "undefined" && $WowheadPower.refreshLinks) {
                     $WowheadPower.refreshLinks();
+                    setTimeout(upgradeWowheadIcons, 1500);
+                } else {
+                    // power.js loads async — wait for it
+                    var attempts = 0;
+                    var wait = setInterval(function () {
+                        attempts++;
+                        if (typeof $WowheadPower !== "undefined" && $WowheadPower.refreshLinks) {
+                            $WowheadPower.refreshLinks();
+                            clearInterval(wait);
+                            setTimeout(upgradeWowheadIcons, 1500);
+                        } else if (attempts > 20) {
+                            clearInterval(wait);
+                        }
+                    }, 250);
                 }
             },
             error: function (xhr, status, error) {
                 loading.hide();
-                mailList.show();
-                emptyMsg.text("Failed to load mails.").show();
+                emptyMsg.text("Failed to load mails.");
+                emptyWrap.show();
                 console.error("Failed to load mails:", error);
             }
         });


### PR DESCRIPTION
Split from the main PR: https://github.com/azerothcore/acore-cms/pull/197

Split by Claude

Realm Settings revamp: SOAP status badge (online/offline on save), live module list from the server, and module-requirement mapping that hides a page when its module is missing. Tools page gets the Web Integration group (security logging, allow-old-passwords, 2FA admin controls, IP-history lookup), Name-Unlock delete buttons moved inside the box + a reset-to-default, and CSRF nonces added to all settings forms (Realm, Tools, Eluna, PvP).

<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/c8ee1582-cac5-427e-8ec2-1aae5c707491" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two-factor authentication management with website and in-game 2FA support
  * Added Security page with login history tracking, password management, and recent connections display
  * Added Dark Mode toggle for WordPress admin interface
  * Enhanced item restoration with new card-based interface
  * Added module management and requirements configuration for server modules
  * Improved mail return interface with character sidebar and item grid layout

* **Bug Fixes**
  * Enhanced security with CSRF protection across all settings forms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->