### PR TITLE
feat(smartstone): gift character services via tokens

### DIFF
--- a/src/acore-wp-plugin/src/Components/AdminPanel/Pages/Tools.php
+++ b/src/acore-wp-plugin/src/Components/AdminPanel/Pages/Tools.php
@@ -61,6 +61,18 @@
                                                 <input type="number" name="acore_resurrection_scroll_days_inactive" id="acore_resurrection_scroll_days_inactive" min="1" value="<?= esc_attr(Opts::I()->acore_resurrection_scroll_days_inactive) ?>">
                                             </td>
                                         </tr>
+                                        <tr>
+                                            <th>
+                                                <label for="acore_smartstone_enabled">Smartstone Token Gifting</label>
+                                                <p class="description">Requires the mod-chromiecraft-smartstone module. Lets buyers gift name/faction/race/customize services as tokens.</p>
+                                            </th>
+                                            <td>
+                                                <select name="acore_smartstone_enabled" id="acore_smartstone_enabled">
+                                                    <option value="0">Disabled</option>
+                                                    <option value="1" <?php if (Opts::I()->acore_smartstone_enabled == '1') echo 'selected'; ?>>Enabled</option>
+                                                </select>
+                                            </td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </div>

--- a/src/acore-wp-plugin/src/Hooks/WooCommerce/CartValidation.php
+++ b/src/acore-wp-plugin/src/Hooks/WooCommerce/CartValidation.php
@@ -63,6 +63,16 @@ class CartValidation extends \ACore\Lib\WpClass {
             return false;
         }
 
+        // Gift via smartstone token: for giftable char-change services, a
+        // recipient name replaces the self character selection. Validate the
+        // recipient and skip the remaining self-service field checks.
+        if (CharChange::isGiftEligible($sku)) {
+            $destName = isset($_REQUEST['acore_char_dest']) ? trim((string) $_REQUEST['acore_char_dest']) : '';
+            if ($destName !== '') {
+                return CharChange::validateGiftRecipient($destName);
+            }
+        }
+
         if (in_array('acore_char_sel', self::$skuList[$activeSku])) {
             $guid = intval($_REQUEST['acore_char_sel'] ?? 0);
 

--- a/src/acore-wp-plugin/src/Hooks/WooCommerce/CharChange.php
+++ b/src/acore-wp-plugin/src/Hooks/WooCommerce/CharChange.php
@@ -3,6 +3,7 @@
 namespace ACore\Hooks\WooCommerce;
 
 use ACore\Manager\ACoreServices;
+use ACore\Manager\Opts;
 
 class CharChange extends \ACore\Lib\WpClass {
 
@@ -14,6 +15,62 @@ class CharChange extends \ACore\Lib\WpClass {
         "char-change-customize",
         "char-restore-delete"
     );
+
+    /**
+     * SKUs that can be gifted through the smartstone token system, mapped to
+     * the mod's TokenType enum (src/Smartstone.h):
+     *   1 = Rename, 2 = Faction change, 3 = Race change, 4 = Customize.
+     * char-restore-delete has no token equivalent and is intentionally absent.
+     */
+    private static $tokenTypes = array(
+        "char-change-name" => 1,
+        "char-change-faction" => 2,
+        "char-change-race" => 3,
+        "char-change-customize" => 4,
+    );
+
+    private static function giftingEnabled(): bool {
+        return Opts::I()->acore_smartstone_enabled == '1';
+    }
+
+    /** A concrete service SKU the buyer may gift (smartstone must be enabled). */
+    public static function isGiftEligible($sku): bool {
+        return self::giftingEnabled() && isset(self::$tokenTypes[$sku]);
+    }
+
+    /**
+     * Whether to offer the gift field on the product page. Uses the display SKU,
+     * which for the variable "char-change" product is the parent (variations all
+     * map to giftable services), so the base SKU is accepted here too.
+     */
+    private static function isGiftableDisplaySku($sku): bool {
+        return self::giftingEnabled()
+            && ($sku === 'char-change' || isset(self::$tokenTypes[$sku]));
+    }
+
+    /**
+     * Validate a gift recipient (character name -> account). Adds a WooCommerce
+     * notice and returns false on any problem. Mirrors the smartstone
+     * account-wide gifting checks.
+     */
+    public static function validateGiftRecipient($destName): bool {
+        $ACoreSrv = ACoreServices::I();
+
+        $char = $ACoreSrv->getCharactersRepo()->findOneByName($destName);
+        if (!$char) {
+            \wc_add_notice(__('Recipient character not found.', 'acore-wp-plugin'), 'error');
+            return false;
+        }
+        if ($ACoreSrv->getCharactersBannedRepo()->isActiveByGuid($char->getGuid())) {
+            \wc_add_notice(__('Recipient character is banned.', 'acore-wp-plugin'), 'error');
+            return false;
+        }
+        if ($ACoreSrv->getAccountBannedRepo()->isActiveById($char->getAccount())) {
+            \wc_add_notice(__('Recipient account is banned.', 'acore-wp-plugin'), 'error');
+            return false;
+        }
+        return true;
+    }
 
     public static function init() {
         add_action('woocommerce_after_add_to_cart_quantity', self::sprefix() . 'before_add_to_cart_button');
@@ -36,6 +93,12 @@ class CharChange extends \ACore\Lib\WpClass {
         if ($current_user) {
             FieldElements::charList($current_user->user_login, self::isDeletedSKU($product->get_sku()));
         }
+
+        // Optional gifting via smartstone token: leaving the field blank keeps
+        // the normal self-service (instant apply to the selected character).
+        if (self::isGiftableDisplaySku($product->get_sku())) {
+            FieldElements::destCharacter(__('Gift to a character (optional, leave blank to apply to your own selected character):', 'acore-wp-plugin'));
+        }
     }
 
     // 3) SAVE INTO ITEM DATA
@@ -43,7 +106,30 @@ class CharChange extends \ACore\Lib\WpClass {
     // ( each cart item has their own data )
     public static function add_cart_item_data($cart_item_data, $product_id, $variation_id) {
         $product = $variation_id ? \wc_get_product($variation_id) : \wc_get_product($product_id);
-        if (!in_array($product->get_sku(), self::$skuList)) {
+        $sku = $product->get_sku();
+        if (!in_array($sku, self::$skuList)) {
+            return $cart_item_data;
+        }
+
+        // Gift mode: a recipient name was supplied for a giftable service. Resolve
+        // it to an account now so payment_complete can grant the token there.
+        // add_to_cart_validation has already vetted existence/ban state.
+        $destName = self::isGiftEligible($sku) && isset($_REQUEST['acore_char_dest'])
+            ? trim((string) $_REQUEST['acore_char_dest'])
+            : '';
+        if ($destName !== '') {
+            $cart_item_data['acore_item_sku'] = $sku;
+            $cart_item_data['unique_key'] = md5(microtime() . rand());
+
+            $ACoreSrv = ACoreServices::I();
+            $char = $ACoreSrv->getCharactersRepo()->findOneByName($destName);
+            if ($char) {
+                $account = $ACoreSrv->getAccountRepo()->findOneById($char->getAccount());
+                if ($account) {
+                    $cart_item_data['acore_gift_account'] = $account->getUsername();
+                    $cart_item_data['acore_gift_charname'] = $char->getName();
+                }
+            }
             return $cart_item_data;
         }
 
@@ -71,6 +157,14 @@ class CharChange extends \ACore\Lib\WpClass {
             return $custom_items;
         }
 
+        if (isset($cart_item['acore_gift_account'])) {
+            $giftCharname = isset($cart_item['acore_gift_charname'])
+                ? $cart_item['acore_gift_charname']
+                : '(recipient)';
+            $custom_items[] = array("name" => 'Gift for', "value" => $giftCharname);
+            return $custom_items;
+        }
+
         if (isset($cart_item['acore_char_sel'])) {
             $ACoreSrv = ACoreServices::I();
             $charRepo = $ACoreSrv->getCharactersRepo();
@@ -92,6 +186,19 @@ class CharChange extends \ACore\Lib\WpClass {
     // This is a piece of code that will add your custom field with order meta.
     public static function add_order_item_meta($item_id, $values, $cart_item_key) {
         if (!in_array($values['acore_item_sku'], self::$skuList)) {
+            return;
+        }
+
+        // Gift: persist the resolved recipient so payment_complete can grant the
+        // token. The account login is stored under an underscore-prefixed key so
+        // WooCommerce keeps it out of customer-facing order details and emails;
+        // only the character name is shown to the buyer. Charname is informational.
+        if (isset($values['acore_gift_account'])) {
+            wc_add_order_item_meta($item_id, "acore_item_sku", $values['acore_item_sku']);
+            wc_add_order_item_meta($item_id, "_acore_gift_account", $values['acore_gift_account']);
+            if (isset($values['acore_gift_charname'])) {
+                wc_add_order_item_meta($item_id, "acore_gift_charname", $values['acore_gift_charname']);
+            }
             return;
         }
 
@@ -135,6 +242,18 @@ class CharChange extends \ACore\Lib\WpClass {
 
             foreach ($items as $item) {
                 if (isset($item["acore_item_sku"])) {
+                    // Gift: grant a token to the recipient's account instead of
+                    // applying the change directly. The recipient redeems it in-game.
+                    if (!empty($item["_acore_gift_account"])
+                        && isset(self::$tokenTypes[$item["acore_item_sku"]])) {
+                        $tokenType = self::$tokenTypes[$item["acore_item_sku"]];
+                        $res = $WoWSrv->getSmartstoneSoap()->grantToken($item["_acore_gift_account"], $tokenType);
+                        if ($res instanceof \Exception) {
+                            throw new \Exception("There was an error granting a token to " . $item["_acore_gift_account"] . " - " . $res->getMessage());
+                        }
+                        continue;
+                    }
+
                     switch ($item["acore_item_sku"]) {
                         case "char-change-name":
                             $charName = $WoWSrv->getCharName($item["acore_char_sel"]);

--- a/src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php
+++ b/src/acore-wp-plugin/src/Hooks/WooCommerce/Smartstone.php
@@ -279,10 +279,11 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
         }
 
         // Gifting: persist the resolved recipient so payment_complete can route
-        // the SOAP unlock to their account. Charname is informational (for admin
-        // order view); only acore_gift_account is functional.
+        // the SOAP unlock to their account. The account login is stored under an
+        // underscore-prefixed key so WooCommerce keeps it out of customer-facing
+        // order details and emails; only the character name is shown to the buyer.
         if (self::isAccountWide($smartstone_category) && isset($values['acore_gift_account'])) {
-            \wc_add_order_item_meta($item_id, "acore_gift_account", $values['acore_gift_account']);
+            \wc_add_order_item_meta($item_id, "_acore_gift_account", $values['acore_gift_account']);
             if (isset($values['acore_gift_charname'])) {
                 \wc_add_order_item_meta($item_id, "acore_gift_charname", $values['acore_gift_charname']);
             }
@@ -340,8 +341,8 @@ class SmartstoneVanity extends \ACore\Lib\WpClass {
                 if (self::isAccountWide($smartstone_category)) {
                     // Gifted items route to the recipient's account; otherwise unlock
                     // for the buyer. Resolution + ban-check happened at add-to-cart time.
-                    $target = !empty($item['acore_gift_account'])
-                        ? $item['acore_gift_account']
+                    $target = !empty($item['_acore_gift_account'])
+                        ? $item['_acore_gift_account']
                         : $accountName;
                     if (!$target) {
                         throw new \Exception("Smartstone account-wide unlock requires a buyer with a linked AC account; order $order_id has none.");

--- a/src/acore-wp-plugin/src/Manager/Opts.php
+++ b/src/acore-wp-plugin/src/Manager/Opts.php
@@ -40,6 +40,7 @@ class Opts {
     public $acore_resurrection_scroll="";
     public $acore_resurrection_scroll_days_inactive="180";
     public $acore_item_restoration="";
+    public $acore_smartstone_enabled="";
     public $acore_name_unlock_thresholds = [
         [5, 30], // level < 5 -> 30 days
         [30, 90], // level < 30 -> 90 days

--- a/src/acore-wp-plugin/src/Manager/Soap/SmartstoneService.php
+++ b/src/acore-wp-plugin/src/Manager/Soap/SmartstoneService.php
@@ -27,4 +27,19 @@ class SmartstoneService {
         return $this->executeCommand(".smartstone unlock account $accountName $category $vanityID true");
     }
 
+    /**
+     * Grant a service token to an account. The recipient redeems it in-game
+     * (`.smartstone token claim`) on the character of their choice.
+     *
+     * $tokenType values come from the mod's TokenType enum (src/Smartstone.h):
+     *   1 = Rename, 2 = Faction change, 3 = Race change, 4 = Customize.
+     *
+     * $accountName is a WordPress user_login (sanitize_user restricts it to
+     * alphanumerics, dot, hyphen, underscore, at - no spaces).
+     */
+    public function grantToken($accountName, $tokenType) {
+        $tokenType = (int) $tokenType;
+        return $this->executeCommand(".smartstone token grant $accountName $tokenType");
+    }
+
 }


### PR DESCRIPTION
## Summary

Adds optional gifting for the **name**, **faction**, **race** and **customization** character services using the smartstone token system in `mod-chromiecraft-smartstone` (the feature was recently renamed from "voucher" to "token").

When a buyer enters a recipient character name on the product page, the purchase grants a token to that account (`.smartstone token grant <account> <type>`, run over SOAP) instead of applying the change directly. The recipient then redeems it in-game (`.smartstone token claim`) on the character of their choice. Leaving the field blank keeps the existing self-service behaviour (instant apply to the selected character), unchanged.

Token types map 1:1 to the services (from the mod's `TokenType` enum): rename=1, faction=2, race=3, customize=4. `char-restore-delete` has no token equivalent and is excluded.

## Config

Gated behind a new **Smartstone Token Gifting** toggle (`acore_smartstone_enabled`) on the admin Tools page, **disabled by default**. With it off, all the new code paths are inert, so behaviour is identical to today unless a server is running the smartstone module and opts in.

## Changes

- `SmartstoneService`: new `grantToken($account, $type)` SOAP helper.
- `CharChange`: optional gift field, recipient resolution (character name to account), token grant on `payment_complete`, and gift display at checkout / in order meta.
- `CartValidation`: validates the gift recipient (exists, not banned, account not banned) and skips the self character-selection requirement in gift mode. Mirrors the existing account-wide smartstone gifting checks.
- `Opts` / `Tools` admin page: the new toggle.
- The recipient account login is stored under a hidden `_acore_gift_account` order-item meta key so WooCommerce keeps it out of customer order details and emails (only the character name is shown). The same fix is applied to the existing account-wide smartstone gifting path, which shared the key.

## Testing

- Toggle off: services behave exactly as before.
- Toggle on, gift field blank: normal self-service.
- Toggle on, recipient name entered: order line shows "Gift for: <name>", and on checkout a token is granted to the recipient account (verified with `.smartstone token list <account>`). Free/$0 orders also work since WooCommerce fires `payment_complete` for zero-total carts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for gifting eligible character-change services to another character.
  * Added recipient validation to prevent gifting to unavailable or banned characters.
  * Added Smartstone token delivery to gift recipients after successful payment.
  * Added an admin setting to enable or disable Smartstone Voucher Gifting.
  * Gift details now appear in cart and order information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->