### PR TITLE
fix(item-restoration): send the REST nonce from the shop page

### DIFF
--- a/src/acore-wp-plugin/src/Hooks/WooCommerce/ItemRestoration.php
+++ b/src/acore-wp-plugin/src/Hooks/WooCommerce/ItemRestoration.php
@@ -175,6 +175,9 @@ class ItemRestoration extends \ACore\Lib\WpClass {
       <div id="item-list-no-content" class="alert alert-info hidden" role="alert">
           <span>There are no items to recover for the selected character</span>
       </div>
+      <div id="item-list-load-error" class="alert alert-danger" role="alert" style="display: none;">
+          <span>We could not load your deleted items, please try again later.</span>
+      </div>
       <div class="table-responsive hidden" id="itemContainer" style="overflow: auto; height: 300px;">
           <table class="table table-bordered table-hover align-middle">
               <thead style="background: #1d2327; color: #fff;">
@@ -198,8 +201,12 @@ class ItemRestoration extends \ACore\Lib\WpClass {
       const itemList = document.getElementById('itemList');
       const itemListLoaders = document.querySelectorAll('.loading-item-list');
       const noResults =  document.getElementById('item-list-no-content');
+      const loadError = document.getElementById('item-list-load-error');
       const loaderIcon = document.getElementById('loader-icon');
       const charList = document.querySelector("#acore_char_sel");
+      // the REST routes require a logged-in user, which cookie auth alone does not
+      // provide: without this nonce WordPress treats the request as anonymous
+      const restNonce = '<?= esc_js(wp_create_nonce('wp_rest')); ?>';
       selectCharacter(charList.value);
 
       charList.onchange = (function (onchange) {
@@ -219,6 +226,7 @@ class ItemRestoration extends \ACore\Lib\WpClass {
 
       function selectCharacter(charGuid) {
         noResults.style.display = 'none';
+        loadError.style.display = 'none';
         loaderIcon.style.display = 'block';
 
         itemListLoaders.forEach(element => element.classList.remove('hidden'));
@@ -226,8 +234,16 @@ class ItemRestoration extends \ACore\Lib\WpClass {
           const character = charGuid;
           const characterName = charList.options[charList.selectedIndex].innerText;
 
-          fetch('<?= get_rest_url(null, 'acore/v1/item-restore/list/'); ?>' + character)
-          .then((response) => response.json())
+          fetch('<?= get_rest_url(null, 'acore/v1/item-restore/list/'); ?>' + character, {
+              headers: { 'Accept': 'application/json', 'X-WP-Nonce': restNonce }
+          })
+          .then((response) => {
+              if (!response.ok) {
+                  throw new Error('Request failed with status ' + response.status);
+              }
+
+              return response.json();
+          })
           .then(function(items) {
 
               loaderIcon.style.display = 'none';
@@ -272,6 +288,11 @@ class ItemRestoration extends \ACore\Lib\WpClass {
 
                   buttonCell.appendChild(button);
               });
+          })
+          .catch(() => {
+              loaderIcon.style.display = 'none';
+              itemContainer.classList.add('hidden');
+              loadError.style.display = 'block';
           })
           .finally(() => {
               $WowheadPower.refreshLinks();


### PR DESCRIPTION
Item restoration is broken on the shop page: no matter how many deleted items a character has, it always says "There are no items to recover for the selected character".

The list endpoint answers 401 for everyone:

```
$ curl -i 'https://<site>/wp-json/acore/v1/item-restore/list/651402'
HTTP/2 401
{"code":"rest_forbidden","message":"Sorry, you are not allowed to do that.","data":{"status":401}}
```

#202 added `permission_callback => is_user_logged_in()` to both item-restore routes, which is the right thing to do, but the shop page still calls them with a bare `fetch()`. Being logged in isn't enough for the REST API: `rest_cookie_check_errors()` calls `wp_set_current_user(0)` when there's no `_wpnonce` param and no `X-WP-Nonce` header, so the request is anonymous and the permission callback rejects it.

The user panel page already got the nonce when it was reworked, so the shop page was the last caller left.

Second half of the fix: the fetch had no `.catch` and didn't look at the status, so an error body has no `.length` and lands in the same branch as an empty list. That's why a 401 was reported to players as "you have nothing to recover". Now a failed request shows an error instead.

### How to test

Buy or open the item-restoration product with a character that has rows in `recovery_item`, they should be listed again. To check the failure path, drop the `X-WP-Nonce` header in devtools and confirm you get the error message rather than the empty state.

### Follow-up, not in here

`item-restore/list` still takes any character guid from any logged-in user, so you can enumerate someone else's deleted items. The POST already checks ownership via `currentAccountOwnsCharacterName()`, the GET could use the same treatment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear error message when item restoration fails to load.
  * Improved request validation to handle unsuccessful responses safely.
  * Preserved loading-state cleanup after both successful and failed requests.
  * Prevented incomplete item content from being displayed when restoration requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->