### PR TITLE
fix(security): don't let a fresh login reset the 2FA attempt counter

### DIFF
--- a/src/acore-wp-plugin/src/Components/ServerInfo/ServerInfoApi.php
+++ b/src/acore-wp-plugin/src/Components/ServerInfo/ServerInfoApi.php
@@ -458,8 +458,10 @@ add_action( 'rest_api_init', function () {
                if ($ingameSecret === '' && !$websiteTotp)
                    return new \WP_Error('cannot_verify', __('In-game 2FA can only be removed inside the game. Log in and type: .account 2fa remove <6-digit-code>', 'acore-wp-plugin'), ['status' => 403]);
 
-               $attemptKey = 'acore_ingame_2fa_remove_attempts_' . acore_2fa_unlock_key($user->ID);
-               if ((int) get_transient($attemptKey) >= 5)
+               // Keyed on the user, not the session: a guessed code strips a game-account
+               // factor, and a per-session counter is reset by logging in again.
+               $attemptKey = 'acore_ingame_2fa_remove_attempts_' . $user->ID;
+               if ((int) get_transient($attemptKey) >= 10)
                    return new \WP_Error('rate_limited', __('Too many incorrect codes. Please wait a few minutes.', 'acore-wp-plugin'), ['status' => 429]);
 
                $data  = $request->get_json_params();
@@ -495,8 +497,9 @@ add_action( 'rest_api_init', function () {
            if (!IngameTotp::isConfigured())
                return new \WP_Error('not_configured', __('In-game 2FA cannot be set up from here. Please set it up inside the game.', 'acore-wp-plugin'), ['status' => 501]);
 
-           $attemptKey = 'acore_ingame_2fa_attempts_' . acore_2fa_unlock_key($user->ID);
-           if ((int) get_transient($attemptKey) >= 5)
+           // Keyed on the user, not the session, so logging in again does not reset it.
+           $attemptKey = 'acore_ingame_2fa_attempts_' . $user->ID;
+           if ((int) get_transient($attemptKey) >= 10)
                return new \WP_Error('rate_limited', __('Too many incorrect codes. Please wait a few minutes.', 'acore-wp-plugin'), ['status' => 429]);
 
            $data  = $request->get_json_params();


### PR DESCRIPTION
Both in-game 2FA attempt counters (the setup one and the removal one) were keyed on `acore_2fa_unlock_key($user->ID)`, which mixes the session token into the key. Logging out and back in gives you a brand new key, so the counter starts from zero and you get five more guesses. With the validator's one step window that's brute forceable given enough logins.

Now they key on the user id alone, so a new session doesn't reset anything. Raised the cap from 5 to 10 since a phone with a skewed clock can legitimately burn a couple of tries.

The website unlock counter next door still uses the old scheme, that one needs its own fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Updated in-game two-factor authentication removal and enablement safeguards to track failed attempts per user.
  * Increased the allowed number of failed attempts from 5 to 10 before rate limiting applies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->