### PR TITLE
fix(admin): stop dark mode leaving light rows behind

### DIFF
--- a/src/acore-wp-plugin/src/Hooks/Various/DarkMode.php
+++ b/src/acore-wp-plugin/src/Hooks/Various/DarkMode.php
@@ -35,7 +35,7 @@ function acore_dark_mode_enqueue() {
     wp_enqueue_style('acore-css', ACORE_URL_PLG . 'web/assets/css/main.css', [], '3.0');
     wp_enqueue_style('acore-dark-mode', ACORE_URL_PLG . 'web/assets/css/dark-mode.css', ['acore-css'], '3.7');
     // Central light/dark theme layer (edit colours here). Loaded last so it wins.
-    wp_enqueue_style('acore-theme', ACORE_URL_PLG . 'web/assets/css/theme.css', ['acore-dark-mode'], '4.0');
+    wp_enqueue_style('acore-theme', ACORE_URL_PLG . 'web/assets/css/theme.css', ['acore-dark-mode'], '4.1');
 
     $nonce = wp_create_nonce('acore_dark_mode');
     wp_add_inline_script('jquery-core', acore_dark_mode_js($nonce));
@@ -148,5 +148,5 @@ function acore_dark_mode_wizard_css() {
         return;
     }
     echo '<link rel="stylesheet" id="acore-theme-wizard-css" media="all" href="'
-        . esc_url(ACORE_URL_PLG . 'web/assets/css/theme.css') . '?ver=4.0" />' . "\n";
+        . esc_url(ACORE_URL_PLG . 'web/assets/css/theme.css') . '?ver=4.1" />' . "\n";
 }

--- a/src/acore-wp-plugin/web/assets/css/theme.css
+++ b/src/acore-wp-plugin/web/assets/css/theme.css
@@ -219,8 +219,13 @@ body.acore-dark-mode.mycred-log-page .wp-list-table th {
     border-color: var(--acore-border) !important;
     background: transparent !important;
 }
+/* myCRED paints both parities itself (odd #fff, even #f6f7f7), so neither can
+   be left to the transparent cells above. */
 body.acore-dark-mode.mycred-log-page .wp-list-table > tbody > tr:nth-child(odd) {
     background: var(--acore-surface-2) !important;
+}
+body.acore-dark-mode.mycred-log-page .wp-list-table > tbody > tr:nth-child(even) {
+    background: var(--acore-surface) !important;
 }
 body.acore-dark-mode.mycred-log-page .wp-list-table a { color: var(--acore-accent) !important; }
 
@@ -242,6 +247,65 @@ body.acore-dark-mode.mycred-log-page #myCRED-wrap h1,
 body.acore-dark-mode.mycred-log-page #myCRED-wrap h2,
 body.acore-dark-mode.mycred-log-page #myCRED-wrap p {
     color: var(--acore-text) !important;
+}
+
+/* ── Dashboard: Activity widget ─────────────────────────────────────────
+ * WP paints the odd post rows and every comment row light (#f6f7f7) and pins
+ * the widget headings to #1d2327 from an id selector, so both need overriding
+ * or the light text sits on a light band. */
+body.acore-dark-mode #dashboard-widgets h3,
+body.acore-dark-mode #dashboard-widgets h4 {
+    color: var(--acore-text);
+}
+body.acore-dark-mode #future-posts li:nth-child(odd),
+body.acore-dark-mode #published-posts li:nth-child(odd),
+body.acore-dark-mode #activity-widget #the-comment-list .comment-item {
+    background: var(--acore-surface-2);
+}
+body.acore-dark-mode #activity-widget #the-comment-list .unapproved {
+    background-color: rgba(240, 180, 41, 0.12);
+}
+body.acore-dark-mode #future-posts li,
+body.acore-dark-mode #published-posts li,
+body.acore-dark-mode #latest-comments #the-comment-list .comment-meta {
+    color: var(--acore-muted);
+}
+body.acore-dark-mode #activity-widget #the-comment-list blockquote,
+body.acore-dark-mode #activity-widget #the-comment-list blockquote p {
+    color: var(--acore-muted);
+}
+body.acore-dark-mode .activity-block,
+body.acore-dark-mode #activity-widget #the-comment-list .comment-item:first-child {
+    border-color: var(--acore-border);
+}
+
+/* ── Recruit a Friend: recruited-friends table ──────────────────────────
+ * Bootstrap leaves the cells transparent and keeps its light text colour, so
+ * pin both here rather than relying on whatever is painted underneath. */
+body.acore-dark-mode #acore-raf-page .table {
+    color: var(--acore-text) !important;
+    border-color: var(--acore-border) !important;
+    --bs-table-bg: transparent;
+    --bs-table-color: var(--acore-text);
+    --bs-table-accent-bg: transparent;
+    --bs-table-striped-bg: transparent;
+    --bs-table-border-color: var(--acore-border);
+}
+body.acore-dark-mode #acore-raf-page .table > :not(caption) > * > * {
+    background-color: var(--acore-surface) !important;
+    color: var(--acore-text) !important;
+    border-color: var(--acore-border) !important;
+    box-shadow: none !important;
+}
+body.acore-dark-mode #acore-raf-page .table thead th,
+body.acore-dark-mode #acore-raf-page .table tbody th {
+    background-color: var(--acore-surface-2) !important;
+}
+body.acore-dark-mode #acore-raf-page .table-hover > tbody > tr:hover > * {
+    background-color: var(--acore-surface-2) !important;
+}
+body.acore-dark-mode #acore-raf-page .text-muted {
+    color: var(--acore-muted) !important;
 }
 
 /* ── WP 2FA standalone setup wizard (profile.php?page=wp-2fa-setup) ──────


### PR DESCRIPTION
Three admin screens still had light rows in dark mode, and since the text on them is light they were basically unreadable.

**Chromie Points History** (`users.php?page=mycred_default-history`): myCRED paints both stripe parities itself (`odd #fff`, `even #f6f7f7`) and we only overrode the odd one, so every second row stayed white.

**Dashboard → Activity**: WP paints the odd "Recently Published" rows and every comment row `#f6f7f7`. It also pins the block headings ("Recently Published", "Recent Comments") to `#1d2327` from `#dashboard-widgets h3`, which our plain `h3` rule can't outweigh, so those headings were dark on dark.

**Recruit a Friend**: the recruited-friends table is a Bootstrap one that leaves its cells transparent and keeps its own light text colour, so it takes whatever is painted underneath. Pinned both explicitly instead.

All of it lives in `theme.css` and is scoped under `body.acore-dark-mode`, so light mode is untouched. Bumped the stylesheet version so browsers pick it up.

Checked on a local wp-admin with dark mode on. Before and after, Activity widget and points history:

| | before | after |
|---|---|---|
| Activity | dark rows only on the even entries, headings invisible | every row dark, headings readable |
| Points history | rows 2 and 4 white with grey text | all rows dark |
