### PR TITLE
fix(smartstone): exempt deleted character restoration from gifting

### DIFF
--- a/src/acore-wp-plugin/src/Hooks/WooCommerce/CharChange.php
+++ b/src/acore-wp-plugin/src/Hooks/WooCommerce/CharChange.php
@@ -128,7 +128,7 @@ class CharChange extends \ACore\Lib\WpClass {
                         }
                     })
                     .on('reset_data', function () {
-                        giftField.hide();
+                        giftField.hide().find('input').val('');
                     });
             });
         </script>

--- a/src/acore-wp-plugin/src/Hooks/WooCommerce/CharChange.php
+++ b/src/acore-wp-plugin/src/Hooks/WooCommerce/CharChange.php
@@ -40,8 +40,10 @@ class CharChange extends \ACore\Lib\WpClass {
 
     /**
      * Whether to offer the gift field on the product page. Uses the display SKU,
-     * which for the variable "char-change" product is the parent (variations all
-     * map to giftable services), so the base SKU is accepted here too.
+     * which for the variable "char-change" product is the parent, so the base
+     * SKU is accepted here too. Not every variation is giftable (deleted
+     * character restoration is not): the field is hidden per variation client
+     * side, and isGiftEligible gates the variation SKU server side.
      */
     private static function isGiftableDisplaySku($sku): bool {
         return self::giftingEnabled()
@@ -98,7 +100,39 @@ class CharChange extends \ACore\Lib\WpClass {
         // the normal self-service (instant apply to the selected character).
         if (self::isGiftableDisplaySku($product->get_sku())) {
             FieldElements::destCharacter(__('Gift to a character (optional, leave blank to apply to your own selected character):', 'acore-wp-plugin'));
+            if ($product->is_type('variable')) {
+                self::giftFieldVariationToggle();
+            }
         }
+    }
+
+    /**
+     * The gift field renders once for the whole variable product, but not every
+     * variation is giftable (char-restore-delete has no token equivalent).
+     * Hide the field, and clear anything typed into it, while a non-giftable
+     * variation is selected. isGiftEligible ignores the recipient server side
+     * either way; this keeps the offer from showing in the first place.
+     */
+    private static function giftFieldVariationToggle(): void {
+        ?>
+        <script>
+            jQuery(function ($) {
+                var giftableSkus = <?= json_encode(array_keys(self::$tokenTypes)) ?>;
+                var giftField = $('.acore-gift-field');
+                $('form.variations_form')
+                    .on('found_variation', function (event, variation) {
+                        var giftable = giftableSkus.indexOf(variation.sku) !== -1;
+                        giftField.toggle(giftable);
+                        if (!giftable) {
+                            giftField.find('input').val('');
+                        }
+                    })
+                    .on('reset_data', function () {
+                        giftField.hide();
+                    });
+            });
+        </script>
+        <?php
     }
 
     // 3) SAVE INTO ITEM DATA

--- a/src/acore-wp-plugin/src/Hooks/WooCommerce/FieldElements.php
+++ b/src/acore-wp-plugin/src/Hooks/WooCommerce/FieldElements.php
@@ -105,9 +105,11 @@ class FieldElements {
 
     public static function destCharacter($label): void {
         ?>
-        <label for="acore_char_dest"><?= $label ?></label>
-        <input type="text" placeholder="Character name..." id="acore_char_dest" class="acore_char_dest" name="acore_char_dest">
-        <br>
+        <div class="acore-gift-field">
+            <label for="acore_char_dest"><?= $label ?></label>
+            <input type="text" placeholder="Character name..." id="acore_char_dest" class="acore_char_dest" name="acore_char_dest">
+            <br>
+        </div>
         <?php
     }
 


### PR DESCRIPTION
Deleted character restoration shouldn't be offered as a gift. The smartstone token gifting from #207 already refuses it during validation and fulfillment, since `char-restore-delete` has no token type. What was still wrong is the shop page: on the variable char-change product the "Gift to a character" field renders once for the parent SKU, so it stays visible when the restoration variation is selected, offering a gift that can't be granted.

The field now hides while a non giftable variation is selected. The giftable SKUs are printed into a small script that listens to WooCommerce's `found_variation` event and toggles the field, clearing anything typed into it when it hides. Standalone restoration products are unaffected, the field was never rendered for them.

**Notes for review**

- Client side toggle instead of a server side check: the field renders before any variation is picked, so PHP can't know which one the buyer will choose. The server side gate (`isGiftEligible` on the variation SKU) already existed and stays the source of truth.
- The input is cleared when hidden so a typed recipient name doesn't ride along in the POST. The server would ignore it for restoration anyway.
- The gift field got a wrapper div in `FieldElements::destCharacter` so the script has something to target. The other pages using the same helper (smartstone vanity, item send, transmog item and itemset) are equally unaffected, nothing there renders the toggle script or targets the wrapper.
- `CharChange.php` (`giftFieldVariationToggle`) is where judgment matters, the `FieldElements.php` change is mechanical.
- Verified by reading, not against a live shop, so the variation event flow wasn't exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)